### PR TITLE
✨ Append resource to error log

### DIFF
--- a/packages/mg-imagescraper/lib/ImageScraper.js
+++ b/packages/mg-imagescraper/lib/ImageScraper.js
@@ -109,6 +109,7 @@ class ImageScraper {
                                 try {
                                     resource[field] = await this.downloadImage(value);
                                 } catch (error) {
+                                    error.resource = resource;
                                     ctx.errors.push(error);
                                     throw error;
                                 }

--- a/packages/mg-imagescraper/lib/ImageScraper.js
+++ b/packages/mg-imagescraper/lib/ImageScraper.js
@@ -122,6 +122,7 @@ class ImageScraper {
                                 try {
                                     resource[field] = await this.processHTML(value);
                                 } catch (error) {
+                                    error.resource = resource;
                                     ctx.errors.push(error);
                                     throw error;
                                 }


### PR DESCRIPTION
no issue

- Adds the resource being scraped to the error log when an error is thrown
- Allows us to more easily track down the offending post