### PR TITLE
Remove srcsets from img wrapped in HTML card

### DIFF
--- a/packages/mg-wp-api/lib/processor.js
+++ b/packages/mg-wp-api/lib/processor.js
@@ -199,6 +199,14 @@ module.exports.processContent = (html, postUrl, errors) => {
         $(gif).attr('src', gifSrc);
     });
 
+    // Remove `srcsets` from `img` wrapped in HTML card
+    $html('img[srcset]').each((i, img) => {
+        $(img).removeAttr('srcset');
+        $(img).removeAttr('sizes');
+        $(img).removeAttr('width');
+        $(img).removeAttr('height');
+    });
+
     /* Buffer specific parser
     ****************************************************/
 


### PR DESCRIPTION
closes https://github.com/TryGhost/migrate/projects/1\#card-35802813

- Sources listed in `srcset` are not downloaded and reference outdated source so they've been removed
- Also removes all `sizes`, `height`, and `width` attributes from images with srcset