### PR TITLE
Improved styled tags behaviour

### DIFF
--- a/packages/mg-wp-api/lib/processor.js
+++ b/packages/mg-wp-api/lib/processor.js
@@ -200,18 +200,19 @@ module.exports.processContent = (html, postUrl, errors) => {
             if (caption) {
                 caption.tagName = 'figcaption';
             }
-        } else if ($(imgChildren).length > 0) {
-            // We don't convert images into image cards when they're wrapped in an HTML card
+        } else {
             // To prevent visual issues, we need to delete `srcset` (we don't scrape those images anyway),
             // `sizes`, and dimensions (for `srcset` images).
-            $(imgChildren).each((i, img) => {
-                if ($(img).attr('srcset')) {
-                    $(img).removeAttr('width');
-                    $(img).removeAttr('height');
-                    $(img).removeAttr('srcset');
-                    $(img).removeAttr('sizes');
-                }
-            });
+            if ($(imgChildren).length > 0) {
+                $(imgChildren).each((i, img) => {
+                    if ($(img).attr('srcset')) {
+                        $(img).removeAttr('width');
+                        $(img).removeAttr('height');
+                        $(img).removeAttr('srcset');
+                        $(img).removeAttr('sizes');
+                    }
+                });
+            }
 
             $(styled).before('<!--kg-card-begin: html-->');
             $(styled).after('<!--kg-card-end: html-->');

--- a/packages/mg-wp-api/lib/processor.js
+++ b/packages/mg-wp-api/lib/processor.js
@@ -185,7 +185,22 @@ module.exports.processContent = (html, postUrl, errors) => {
     // Wrap inline styled tags in HTML card
     $html('div[style], p[style], a[style], span[style]').each((i, styled) => {
         let imgChildren = $(styled).children('img:not([data-gif])');
-        if ($(imgChildren).length > 0) {
+
+        // If this is a simple element with a single image using src, we aren't going to do anything special
+        if ($(imgChildren).length === 1 && $(imgChildren.get(0)).attr('src')) {
+            styled.tagName = 'figure';
+            let img = $(imgChildren.get(0));
+
+            if (img.hasClass('size-full')) {
+                img.addClass('kg-width-wide');
+            }
+
+            let caption = $(styled).find('.wp-caption-text').get(0);
+
+            if (caption) {
+                caption.tagName = 'figcaption';
+            }
+        } else if ($(imgChildren).length > 0) {
             // We don't convert images into image cards when they're wrapped in an HTML card
             // To prevent visual issues, we need to delete `srcset` (we don't scrape those images anyway),
             // `sizes`, and dimensions (for `srcset` images).
@@ -193,13 +208,14 @@ module.exports.processContent = (html, postUrl, errors) => {
                 if ($(img).attr('srcset')) {
                     $(img).removeAttr('width');
                     $(img).removeAttr('height');
+                    $(img).removeAttr('srcset');
+                    $(img).removeAttr('sizes');
                 }
-                $(img).removeAttr('srcset');
-                $(img).removeAttr('sizes');
             });
+
+            $(styled).before('<!--kg-card-begin: html-->');
+            $(styled).after('<!--kg-card-end: html-->');
         }
-        $(styled).before('<!--kg-card-begin: html-->');
-        $(styled).after('<!--kg-card-end: html-->');
     });
 
     // Some header elements contain span children to use custom inline styling. Wrap 'em in HTML cards.

--- a/packages/mg-wp-api/test/fixtures/single-post.json
+++ b/packages/mg-wp-api/test/fixtures/single-post.json
@@ -15,7 +15,7 @@
     "rendered": "My Awesome Post"
   },
   "content": {
-    "rendered": "\n<h2><strong>This is my strong headline thing.<\/strong><\/h2>\n\n\n\n<p><em>Note: this article contains awesomeness<\/em><\/p>\n\n\n\n<p>This is a paragraph of text. This is a very short dummy post.<\/p>\n\n\n\n<div style=\"height:43px\" aria-hidden=\"true\" class=\"wp-block-spacer\"><\/div>\n",
+    "rendered": "\n<h2><strong>This is my strong headline thing.<\/strong><\/h2>\n\n\n\n<p><em>Note: this article contains awesomeness<\/em><\/p>\n\n\n\n<p>This is a paragraph of text. This is a very short dummy post.<\/p>\n\n\n\n<div style=\"height:43px\" aria-hidden=\"true\" class=\"wp-block-spacer\"><\/div>\n\n<div id=\"attachment_15945\" style=\"width: 1148px\" class=\"wp-caption aligncenter\"><img src=\"https://mysite.com/wp-content/uploads/2020/06/image.png\" /><span class=\"wp-caption-text\">My awesome image</span><\/div>\n<div style=\"width: 1148px\"><img src=\"https://mysite.com/wp-content/uploads/2020/06/image.png\" srcset=\"https://mysite.com/wp-content/uploads/2020/06/image.png\" sizes=\"https://mysite.com/wp-content/uploads/2020/06/image.png\" width=\"600\" height=\"400\"/><img src=\"https://mysite.com/wp-content/uploads/2020/06/another_image.png\" srcset=\"https://mysite.com/wp-content/uploads/2020/06/another_image.png\" sizes=\"https://mysite.com/wp-content/uploads/2020/06/another_image.png\" width=\"600\" height=\"400\"/><span class=\"wp-caption-text\">srcset images</span><\/div>",
     "protected": false
   },
   "excerpt": {

--- a/packages/mg-wp-api/test/process.test.js
+++ b/packages/mg-wp-api/test/process.test.js
@@ -18,8 +18,9 @@ describe('Process', function () {
         const data = post.data;
         data.slug.should.eql('my-awesome-post');
         data.title.should.eql('My Awesome Post');
+
         // data.excerpt.should.eql('This is my strong headline thing. Here we have some excerpt content [&hellip;]');
-        data.html.should.eql('\n<h2><strong>This is my strong headline thing.<\/strong><\/h2>\n\n\n\n<p><em>Note: this article contains awesomeness<\/em><\/p>\n\n\n\n<p>This is a paragraph of text. This is a very short dummy post.<\/p>\n\n\n\n<!--kg-card-begin: html--><div style=\"height:43px\" aria-hidden=\"true\" class=\"wp-block-spacer\"><\/div><!--kg-card-end: html-->\n'); /* eslint-disable-line no-useless-escape */
+        data.html.should.eql('\n<h2><strong>This is my strong headline thing.<\/strong><\/h2>\n\n\n\n<p><em>Note: this article contains awesomeness<\/em><\/p>\n\n\n\n<p>This is a paragraph of text. This is a very short dummy post.<\/p>\n\n\n\n<!--kg-card-begin: html--><div style=\"height:43px\" aria-hidden=\"true\" class=\"wp-block-spacer\"><\/div><!--kg-card-end: html-->\n\n<figure id=\"attachment_15945\" style=\"width: 1148px\" class=\"wp-caption aligncenter\"><img src=\"https://mysite.com/wp-content/uploads/2020/06/image.png\"><figcaption class=\"wp-caption-text\">My awesome image<\/figcaption><\/figure>\n<!--kg-card-begin: html--><div style=\"width: 1148px\"><img src=\"https://mysite.com/wp-content/uploads/2020/06/image.png\"><img src=\"https://mysite.com/wp-content/uploads/2020/06/another_image.png\"><span class=\"wp-caption-text\">srcset images<\/span><\/div><!--kg-card-end: html-->'); /* eslint-disable-line no-useless-escape */
 
         data.tags.should.be.an.Array().with.lengthOf(6);
         data.tags[5].data.name.should.eql('#wp');


### PR DESCRIPTION
- styled tags that contain only one image should be converted into a standard image card (`figure`)
- styled tags that contain multiple children still need to be wrapped in an HTML card
- Updated tests to reflect changes