### PR TITLE
🎨 Use post_date for updated_at and created_at fields

### DIFF
--- a/packages/mg-hubspot-api/lib/processor.js
+++ b/packages/mg-hubspot-api/lib/processor.js
@@ -1,6 +1,7 @@
 const htmlToText = require('html-to-text');
 const $ = require('cheerio');
 const url = require('url');
+const {getTime} = require('date-fns');
 
 const VideoError = ({src, postUrl}) => {
     let error = new Error(`Unsupported video ${src} in post ${postUrl}`);
@@ -246,17 +247,21 @@ module.exports.processContent = (html, postUrl, errors) => {
  * }
  */
 module.exports.processPost = (hsPost, tags, errors) => {
+    // Get the current timestamp - https://date-fns.org/docs/getTime
+    const timestampNow = getTime(new Date());
+
     const post = {
         url: hsPost.url,
         data: {
             slug: hsPost.slug,
             title: hsPost.name || hsPost.html_title,
             comment_id: hsPost.analytics_page_id,
-            created_at: hsPost.created_time,
+            created_at: hsPost.created_time || timestampNow,
+            published_at: hsPost.publish_date || timestampNow,
+            updated_at: hsPost.updated || timestampNow,
             meta_title: hsPost.page_title || hsPost.title,
             meta_description: hsPost.meta_description,
-            status: hsPost.state.toLowerCase(),
-            published_at: hsPost.publish_date
+            status: hsPost.state.toLowerCase()
 
         }
     };

--- a/packages/mg-hubspot-api/lib/processor.js
+++ b/packages/mg-hubspot-api/lib/processor.js
@@ -1,7 +1,7 @@
 const htmlToText = require('html-to-text');
 const $ = require('cheerio');
 const url = require('url');
-const {getTime} = require('date-fns');
+const {formatISO, parse} = require('date-fns');
 
 const VideoError = ({src, postUrl}) => {
     let error = new Error(`Unsupported video ${src} in post ${postUrl}`);
@@ -247,8 +247,8 @@ module.exports.processContent = (html, postUrl, errors) => {
  * }
  */
 module.exports.processPost = (hsPost, tags, errors) => {
-    // Get the current timestamp - https://date-fns.org/docs/getTime
-    const timestampNow = getTime(new Date());
+    // Get an ISO 8601 date - https://date-fns.org/docs/formatISO
+    const dateNow = formatISO(new Date());
 
     const post = {
         url: hsPost.url,
@@ -256,9 +256,9 @@ module.exports.processPost = (hsPost, tags, errors) => {
             slug: hsPost.slug,
             title: hsPost.name || hsPost.html_title,
             comment_id: hsPost.analytics_page_id,
-            created_at: hsPost.created_time || timestampNow,
-            published_at: hsPost.publish_date || timestampNow,
-            updated_at: hsPost.updated || timestampNow,
+            created_at: formatISO(parse(hsPost.created_time)) || dateNow,
+            published_at: formatISO(parse(hsPost.publish_date)) || dateNow,
+            updated_at: formatISO(parse(hsPost.updated)) || dateNow,
             meta_title: hsPost.page_title || hsPost.title,
             meta_description: hsPost.meta_description,
             status: hsPost.state.toLowerCase()

--- a/packages/mg-hubspot-api/package.json
+++ b/packages/mg-hubspot-api/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "cheerio": "0.22.0",
+    "date-fns": "2.16.1",
     "html-to-text": "^5.1.1",
     "hubspot-api": "2.15.3"
   }

--- a/packages/mg-medium-export/lib/process-post.js
+++ b/packages/mg-medium-export/lib/process-post.js
@@ -1,10 +1,14 @@
 const $ = require('cheerio');
+const {formatISO} = require('date-fns');
 const string = require('@tryghost/string');
 const processContent = require('./process-content');
 const sectionTags = ['aside', 'blockquote', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'img'];
 
 const processMeta = (name, $post) => {
     let urlInfo;
+
+    // Get an ISO 8601 date - https://date-fns.org/docs/formatISO
+    const dateNow = formatISO(new Date());
 
     const post = {
         url: $post('.p-canonical').attr('href'),
@@ -18,10 +22,14 @@ const processMeta = (name, $post) => {
         urlInfo = name.match(/_(.*?)-([0-9a-f]+)\.html/);
         post.url = $post('footer p a').attr('href');
         post.data.status = 'draft';
+        post.data.created_at = dateNow;
+        post.data.updated_at = dateNow;
     } else {
         urlInfo = post.url.match(/([^/]*?)-([0-9a-f]+)$/);
         post.data.status = 'published';
-        post.data.published_at = $post('.dt-published').attr('datetime');
+        post.data.created_at = $post('.dt-published').attr('datetime') || dateNow;
+        post.data.published_at = $post('.dt-published').attr('datetime') || dateNow;
+        post.data.updated_at = $post('.dt-published').attr('datetime') || dateNow;
     }
 
     $('img').map(async (i, el) => {

--- a/packages/mg-medium-export/package.json
+++ b/packages/mg-medium-export/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@tryghost/mg-fs-utils": "^0.7.1",
     "@tryghost/string": "0.1.12",
-    "cheerio": "0.22.0"
+    "cheerio": "0.22.0",
+    "date-fns": "2.16.1"
   }
 }

--- a/packages/mg-medium-export/test/process.test.js
+++ b/packages/mg-medium-export/test/process.test.js
@@ -18,7 +18,11 @@ describe('Process', function () {
         post.data.slug.should.eql('testpost');
         post.data.custom_excerpt.should.eql('This is a subtitle of some sort');
         post.data.status.should.eql('published');
+
+        post.data.created_at.should.eql('2018-08-11T11:23:34.123Z');
         post.data.published_at.should.eql('2018-08-11T11:23:34.123Z');
+        post.data.updated_at.should.eql('2018-08-11T11:23:34.123Z');
+
         post.data.html.should.match(/^<section name="007"/);
         post.data.html.should.match(/<\/section>$/);
 

--- a/packages/mg-revue-api/lib/processor.js
+++ b/packages/mg-revue-api/lib/processor.js
@@ -181,6 +181,8 @@ module.exports.processPost = (data, {addPrimaryTag, email, pubName}) => {
             title: data.title,
             meta_title: data.page_title || data.title,
             status: 'published',
+            created_at: data.sent_at,
+            updated_at: data.sent_at,
             published_at: data.sent_at,
             tags: []
         }

--- a/packages/mg-squarespace-xml/lib/process.js
+++ b/packages/mg-squarespace-xml/lib/process.js
@@ -141,13 +141,18 @@ module.exports.processPost = ($sqPost, users, {addTag, tags: fetchTags, siteUrl}
             postSlug = 'untitled';
         }
 
+        // WP XML only provides a published date, we let's use that all dates Ghost expects
+        const postDate = parse($($sqPost).children('pubDate').text(), 'EEE, d MMM yyyy HH:mm:ss xx', new Date());
+
         const post = {
             url: `${siteUrl}${$($sqPost).children('link').text()}`,
             data: {
                 slug: $($sqPost).children('wp\\:post_name').text().replace(/(\.html)/i, ''),
                 title: $($sqPost).children('title').text(),
                 status: $($sqPost).children('wp\\:status').text() === 'publish' ? 'published' : 'draft',
-                published_at: parse($($sqPost).children('pubDate').text(), 'EEE, d MMM yyyy HH:mm:ss xx', new Date()),
+                published_at: postDate,
+                created_at: postDate,
+                updated_at: postDate,
                 feature_image: featureImage,
                 type: postType,
                 author: users ? users.find(user => user.data.slug === authorSlug) : null,

--- a/packages/mg-squarespace-xml/test/process.test.js
+++ b/packages/mg-squarespace-xml/test/process.test.js
@@ -27,6 +27,8 @@ describe('Process', function () {
         data.title.should.eql('Basic Post');
         data.status.should.eql('published');
         data.published_at.should.eql(new Date('2013-06-07T03:00:44.000Z'));
+        data.created_at.should.eql(new Date('2013-06-07T03:00:44.000Z'));
+        data.updated_at.should.eql(new Date('2013-06-07T03:00:44.000Z'));
         data.feature_image.should.eql('https://images.unsplash.com/photo-1601276861758-2d9c5ca69a17?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1268&q=80');
         data.type.should.eql('post');
         data.html.should.eql('<div class="image-block-outer-wrapper layout-caption-below design-layout-inline" data-test="image-block-inline-outer-wrapper"> <figure class="sqs-block-image-figure intrinsic" style="max-width:409.0px;"> <a class="sqs-block-image-link" href="https://anothersite.co.uk" target="_blank"> <div style="padding-bottom:37.4083137512207%;" lass="image-block-wrapper" data-animation-role="image" data-animation-override> <noscript><img src="https://images.unsplash.com/photo-1601275225755-f6a6c1730cb1?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2765&q=80"></noscript>  </div> </a> </figure> </div> <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris pellentesque nisi sed neque vestibulum pulvinar.</p> <p>Integer iaculis ac elit a bibendum. Suspendisse rhoncus vitae dui vitae ultrices.</p> <!--kg-card-begin: html--><table> <thead> <tr> <th>Width</th> <th>Height</th> </tr> </thead> <tbody> <tr> <td>20</td> <td>15</td> </tr> <tr> <td>40</td> <td>30</td> </tr> </tbody> </table><!--kg-card-end: html--> <p>Aenean velit mi, <a href="https://anothersite.co.uk" target="_blank">dapibus</a> eget ex sed, viverra ultrices mi. Nunc at odio bibendum, gravida lectus sit amet, congue dui. Mauris id justo ante. Cras viverra suscipit bibendum.</p> <p><strong>Sed vulputate consectetur tortor:</strong></p> <ul> <li>Lobortis mauris dapibus in</li> <li>Donec pharetra, orci sit amet fermentum</li> <li>Pretium, nisi arcu molestie mi, nec</li> <li>Consequat turpis tortor vulputate quam, mauris vel quam turpis</li> </ul> <p></p> <p>Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Nulla aliquet neque eu lectus sollicitudin, sit amet vestibulum diam commodo.</p> <p>&nbsp;</p> <p>&nbsp;</p> <p>&nbsp;</p>');
@@ -72,6 +74,8 @@ describe('Process', function () {
         data.title.should.eql('Draft Post');
         data.status.should.eql('draft');
         data.published_at.should.eql(new Date('2013-11-02T23:02:32.000Z'));
+        data.created_at.should.eql(new Date('2013-11-02T23:02:32.000Z'));
+        data.updated_at.should.eql(new Date('2013-11-02T23:02:32.000Z'));
         should.not.exist(data.feature_image);
         data.type.should.eql('post');
         data.html.should.eql('<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. </p>');

--- a/packages/mg-substack-csv/lib/mapper.js
+++ b/packages/mg-substack-csv/lib/mapper.js
@@ -1,12 +1,19 @@
+const {formatISO} = require('date-fns');
+
 const mapConfig = (data, {url, readPosts, email}) => {
     const slug = data.post_id.replace(/^(?:\d{1,10}\.)(\S*)/gm, '$1');
+
+    // Get an ISO 8601 date - https://date-fns.org/docs/formatISO
+    const dateNow = formatISO(new Date());
 
     const mappedData = {
         url: `${url}/${slug}`,
         substackId: data.post_id,
         data: {
             slug: slug,
-            published_at: data.post_date,
+            published_at: data.post_date || dateNow,
+            updated_at: data.post_date || dateNow,
+            created_at: data.post_date || dateNow,
             title: data.title || slug,
             custom_excerpt: data.subtitle,
             type: 'post',

--- a/packages/mg-substack-csv/package.json
+++ b/packages/mg-substack-csv/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "bluebird": "^3.7.2",
     "csv-parse": "4.12.0",
+    "date-fns": "2.16.1",
     "ghost-ignition": "4.2.2",
     "lodash": "4.17.20"
   }

--- a/packages/mg-substack-csv/test/process.test.js
+++ b/packages/mg-substack-csv/test/process.test.js
@@ -40,6 +40,8 @@ describe('Convert Substack CSV format to Ghost JSON format', function () {
 
         data.slug.should.eql('plain-text');
         data.published_at.should.eql('2019-07-26T20:48:19.814Z');
+        data.updated_at.should.eql('2019-07-26T20:48:19.814Z');
+        data.created_at.should.eql('2019-07-26T20:48:19.814Z');
         data.title.should.eql('Plain Text');
         data.html.should.eql('<h2>Lorem Ipsum</h2>\n<a class="button primary" href="/subscribe/"><span>Sign up now</span></a>\n<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt.</p>\n<p>Dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco.</p>\n<div><hr></div>\n<a class="button primary" href="/subscribe/"><span>Sign up now</span></a>\n');
         data.custom_excerpt.should.eql('Lorem ipsum dolor sit amet.');

--- a/packages/mg-wp-api/lib/processor.js
+++ b/packages/mg-wp-api/lib/processor.js
@@ -425,7 +425,9 @@ module.exports.processPost = (wpPost, users, options, errors) => {
             html: wpPost.content.rendered,
             type: wpPost.type === 'post' ? 'post' : 'page',
             status: wpPost.status === 'publish' ? 'published' : 'draft',
+            created_at: wpPost.date_gmt,
             published_at: wpPost.date_gmt,
+            updated_at: wpPost.modified_gmt,
             author: users ? users.find((user) => {
                 // Try to use the user data returned from the API
                 return user.data.id === wpPost.author;

--- a/packages/mg-wp-api/test/process.test.js
+++ b/packages/mg-wp-api/test/process.test.js
@@ -17,6 +17,9 @@ describe('Process', function () {
         post.data.should.be.an.Object();
         const data = post.data;
 
+        data.created_at.should.eql('2019-11-07T15:36:54');
+        data.published_at.should.eql('2019-11-07T15:36:54');
+        data.updated_at.should.eql('2019-11-07T15:37:03');
         data.slug.should.eql('my-awesome-post-with-a-canonical');
         data.title.should.eql('My Awesome Post');
 
@@ -88,7 +91,10 @@ describe('Process', function () {
         const data = page.data;
         data.type.should.eql('page');
 
+        data.created_at.should.eql('2020-09-17T11:49:03');
         data.published_at.should.eql('2020-09-17T11:49:03');
+        data.updated_at.should.eql('2020-09-18T11:15:32');
+
         data.slug.should.eql('sample-page');
         data.title.should.eql('Sample Page');
 


### PR DESCRIPTION
no issue

All of the sources here have a `created_at` field, but not all had `updated_at` or `published_at`.

When importing into Ghost, if no `updated_at` field was supplied, it adds the current time, giving the impression that all posts were updated en-masse. While this is technically true as the post formatting likely changed as part of the migration, it's not the greatest UX.

This PR adds those missing date fields to all sources, using dates from the original data if available.