### PR TITLE
🗑 Add command to empty locally cached migration files

### DIFF
--- a/packages/mg-fs-utils/lib/FileCache.js
+++ b/packages/mg-fs-utils/lib/FileCache.js
@@ -21,6 +21,10 @@ class FileCache {
         }
     }
 
+    get cacheBaseDir() {
+        return path.join(os.tmpdir(), basePath);
+    }
+
     get cacheKey() {
         if (!this._cacheKey) {
             // Unique hash based on full zip path + the original filename
@@ -231,6 +235,45 @@ class FileCache {
         }
 
         return fs.existsSync(pathToCheck);
+    }
+
+    /**
+     * Empties the local cache directory
+     */
+    async emptyCacheDir() {
+        const directory = this.cacheBaseDir + '/';
+
+        fs.existsSync(directory, (err) => {
+            if (err) {
+                throw err;
+            }
+            return true;
+        });
+
+        let itemsToDelete = [];
+        const dirContents = fs.readdirSync(directory).map((fileName) => {
+            return path.join(directory, fileName);
+        });
+
+        dirContents.forEach((item) => {
+            if (fs.lstatSync(item).isDirectory()) {
+                itemsToDelete.push(item);
+            }
+        });
+
+        itemsToDelete.forEach((item) => {
+            fs.rmdir(item, {recursive: true}, (err) => {
+                if (err) {
+                    throw err;
+                }
+                return true;
+            });
+        });
+
+        return {
+            directory: directory,
+            files: itemsToDelete
+        };
     }
 }
 

--- a/packages/migrate/commands/cache.js
+++ b/packages/migrate/commands/cache.js
@@ -1,0 +1,43 @@
+const fsUtils = require('../../mg-fs-utils');
+const ui = require('@tryghost/pretty-cli').ui;
+
+// Internal ID in case we need one.
+exports.id = 'clear-cache';
+
+exports.group = 'Commands:';
+
+// The command to run and any params
+exports.flags = 'clear-cache';
+
+// Description for the top level command
+exports.desc = 'Clear local migration cache';
+
+// Configure all the options
+exports.setup = (sywac) => {
+    sywac.boolean('-V --verbose', {
+        defaultValue: false,
+        desc: 'Show verbose output'
+    });
+};
+
+// What to do when this command is executed
+exports.run = async (argv) => {
+    try {
+        let fsCache = new fsUtils.FileCache('test.dev', 'yolo');
+        let cacheDir = fsCache.cacheBaseDir;
+
+        ui.log.info(`Emptying the directory located at: ${cacheDir}/`);
+
+        const clear = await fsCache.emptyCacheDir();
+
+        if (argv.verbose) {
+            clear.files.forEach((item) => {
+                ui.log.info(`Deleted: ${item}`);
+            });
+        }
+
+        ui.log.ok(`Deleted ${clear.files.length} files`);
+    } catch (error) {
+        ui.log.info('Done with errors', error);
+    }
+};


### PR DESCRIPTION
After running several migrations, the local cache directory can get quite large.
This directory is buried quite deep, like below, and can be difficult to find to clear manually.

```
/var/folders/4p/uaoeni5er9ab5e2wckunsldvx8ncht/T/mg/yqctfcmelg65vukp63rnfg2a52fwsevm-dummy-site
```

This adds a command `migrate clear-cache` to empty this directory.
You can add `--verbose` to see the deleted that are deleted.