### PR TITLE
🐛 Fix fsUtils require path

### DIFF
--- a/packages/migrate/commands/cache.js
+++ b/packages/migrate/commands/cache.js
@@ -1,4 +1,4 @@
-const fsUtils = require('../../mg-fs-utils');
+const fsUtils = require('@tryghost/mg-fs-utils');
 const ui = require('@tryghost/pretty-cli').ui;
 
 // Internal ID in case we need one.


### PR DESCRIPTION
no issue

- the CLI was broken because the require path was wrong
- changed the require path to reference the NPM package