### PR TITLE
Enable dated permalinks in WP sites

### DIFF
--- a/packages/mg-linkfixer/lib/LinkFixer.js
+++ b/packages/mg-linkfixer/lib/LinkFixer.js
@@ -15,9 +15,18 @@ class LinkFixer {
         if (!ctx.result.posts) {
             return;
         }
-        // @TODO: support for custom permalinks and taxonomies
+
+        // @TODO: support for custom taxonomies
         ctx.result.posts.forEach(({url, data}) => {
-            this.linkMap[url] = `/${data.slug}/`;
+            const RegexYYYYMMDD = new RegExp(`^${ctx.options.url}/([0-9]{4}/[0-9]{2}/[0-9]{2})/([a-zA-Z0-9-_]*)(/)?`);
+            const isDatedPermalink = url.match(RegexYYYYMMDD);
+
+            if (ctx.options.datedPermalinks === '/yyyy/mm/dd/' && isDatedPermalink) {
+                this.linkMap[url] = `/${url.replace(RegexYYYYMMDD, '$1/$2')}/`;
+            } else {
+                this.linkMap[url] = `/${data.slug}/`;
+            }
+
             if (data.tags) {
                 data.tags.forEach(({url: tagUrl, data: tagData}) => {
                     this.linkMap[tagUrl] = `/tag/${tagData.slug}/`;

--- a/packages/mg-linkfixer/test/LinkFixer.test.js
+++ b/packages/mg-linkfixer/test/LinkFixer.test.js
@@ -6,24 +6,26 @@ const linkFixer = require('../lib/LinkFixer');
 const mgJSON = require('@tryghost/mg-json');
 const makeTaskRunner = require('../../migrate/lib/task-runner.js');
 
+const getPosts = async (options = {}) => {
+    let ctx = testUtils.fixtures.readSync('ctx.json');
+
+    ctx.options = {...ctx.options, ...options};
+
+    ctx.linkFixer = new linkFixer();
+    ctx.linkFixer.buildMap(ctx);
+    ctx.result = mgJSON.toGhostJSON(ctx.result, ctx.options);
+
+    let tasks = ctx.linkFixer.fix(ctx, []);
+
+    const doTasks = makeTaskRunner(tasks, {renderer: 'silent'});
+    await doTasks.run();
+
+    return ctx.result.data.posts;
+};
+
 describe('LinkFixer', function () {
-    before(async function () {
-        let ctx = require(testUtils.fixturesFilename('ctx.json'));
-
-        ctx.linkFixer = new linkFixer();
-        ctx.linkFixer.buildMap(ctx);
-        ctx.result = mgJSON.toGhostJSON(ctx.result, ctx.options);
-
-        let tasks = ctx.linkFixer.fix(ctx, []);
-
-        const doTasks = makeTaskRunner(tasks, {renderer: 'silent'});
-        await doTasks.run();
-
-        this.posts = ctx.result.data.posts;
-    });
-
-    it('Fixes links to posts', function () {
-        const posts = this.posts;
+    it('Fixes links to posts', async function () {
+        const posts = await getPosts();
 
         posts.should.be.an.Array().with.lengthOf(5);
 
@@ -31,8 +33,19 @@ describe('LinkFixer', function () {
         posts[3].html.should.containEql('<a href="/lorem-ipsum/">Consectetur</a>');
     });
 
-    it('Fixes links to pages', function () {
-        const posts = this.posts;
+    it('Fixes dated links to posts', async function () {
+        const posts = await getPosts({
+            datedPermalinks: '/yyyy/mm/dd/'
+        });
+
+        posts.should.be.an.Array().with.lengthOf(5);
+
+        posts[3].html.should.not.containEql('<a href="https://example.com/2020/06/27/lorem-ipsum/">Consectetur</a>');
+        posts[3].html.should.containEql('<a href="/2020/06/27/lorem-ipsum/">Consectetur</a>');
+    });
+
+    it('Fixes links to pages', async function () {
+        const posts = await getPosts();
 
         posts[0].html.should.not.containEql('<a href="https://example.com/sample-page/">aspernatur</a>');
         posts[0].html.should.containEql('<a href="/sample-page/">aspernatur</a>');
@@ -41,22 +54,22 @@ describe('LinkFixer', function () {
         posts[2].html.should.containEql('<a href="/child-sample-page/">quis</a>');
     });
 
-    it('Does not replace external links', function () {
-        const posts = this.posts;
+    it('Does not replace external links', async function () {
+        const posts = await getPosts();
 
         posts[0].html.should.containEql('<a href="https://dummyurl.com/eos-quia-quos-voluptas-aliquam-et-et-omnis.html">Sunt tempore nisi similique</a>');
         posts[0].html.should.not.containEql('<a href="/eos-quia-quos-voluptas-aliquam-et-et-omnis.html">Sunt tempore nisi similique</a>');
     });
 
-    it('Does replace tag links that were migrated', function () {
-        const posts = this.posts;
+    it('Does replace tag links that were migrated', async function () {
+        const posts = await getPosts();
 
         posts[1].html.should.not.containEql('<a href="https://example.com/category/cakes/fruit/">dolor</a>');
         posts[1].html.should.containEql('<a href="/tag/fruit/">dolor</a>');
     });
 
-    it('Does not replace tag links that was not migrated', function () {
-        const posts = this.posts;
+    it('Does not replace tag links that were not migrated', async function () {
+        const posts = await getPosts();
 
         posts[0].html.should.containEql('<a href="https://example.com/tag/delivery/">soluta</a>');
         posts[0].html.should.not.containEql('<a href="/tag/delivery/">soluta</a>');

--- a/packages/mg-linkfixer/test/utils/fixtures.js
+++ b/packages/mg-linkfixer/test/utils/fixtures.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+
+module.exports.readSync = (name) => {
+    let fixtureFileName = path.join(__dirname, '../', 'fixtures', name);
+    let content = fs.readFileSync(fixtureFileName, {encoding: 'utf8'});
+
+    if (path.extname(name) === '.json') {
+        return JSON.parse(content);
+    }
+
+    return content;
+};

--- a/packages/mg-linkfixer/test/utils/index.js
+++ b/packages/mg-linkfixer/test/utils/index.js
@@ -3,12 +3,10 @@
  *
  * Shared utils for writing tests
  */
-const path = require('path');
-
 // Require overrides - these add globals for tests
 require('./overrides');
 
 // Require assertions - adds custom should assertions
 require('./assertions');
 
-module.exports.fixturesFilename = name => path.join(__dirname, '../', 'fixtures', name);
+module.exports.fixtures = require('./fixtures');

--- a/packages/mg-wp-api/README.md
+++ b/packages/mg-wp-api/README.md
@@ -68,6 +68,10 @@ It's possible to pass more options, in order to achieve a better migration file 
 - **`--excerptSelector`**
     - string - default: `null`
     - Pass in a valid selector to grab a custom excerpt from the post content, e. g. `h2.excerpt`
+- **`--datedPermalinks`** 
+    - Set the dated permalink structure
+    - string - default: `none` 
+    - Choices: `none`, `'/yyyy/mm/dd/'`  
 - **`--fallBackHTMLCard`** 
     - Fall back to convert to HTMLCard, if standard Mobiledoc convert fails
     - bool - default: `false`

--- a/packages/migrate/commands/wp-api.js
+++ b/packages/migrate/commands/wp-api.js
@@ -67,6 +67,11 @@ exports.setup = (sywac) => {
         choices: ['featuredmedia', 'og:image', 'none'],
         desc: 'Change which value is used as the feature image'
     });
+    sywac.enumeration('--datedPermalinks', {
+        choices: ['none', '/yyyy/mm/dd/'],
+        defaultValue: 'none',
+        desc: 'Set the dated permalink structure (e.g. /yyyy/mm/dd/)'
+    });
     sywac.string('--excerptSelector', {
         defaultValue: null,
         desc: 'Pass in a valid selector to grab a custom excerpt from the post content, e. g. `h2.excerpt`'


### PR DESCRIPTION
- Previously, all WP migrations changed URLs to remove dated permalinks, if they were present, so `.com/2021/06/14/my-post` would become `.com/my-post`
- This PR adds the functionality to @tryghost/mg-linkfixer, and a flag to the WP tools that retains dated permalinks in the final JSON file
- Currently, only `/yyyy/mm/dd/` is supported