### PR TITLE
WP: Handle bookmarks

### DIFF
--- a/packages/mg-wp-api/package.json
+++ b/packages/mg-wp-api/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@tryghost/errors": "1.1.1",
+    "@tryghost/mg-webscraper": "0.6.22",
     "cheerio": "0.22.0",
     "wpapi": "^1.2.1"
   }

--- a/packages/mg-wp-api/test/process.test.js
+++ b/packages/mg-wp-api/test/process.test.js
@@ -4,11 +4,11 @@ const testUtils = require('./utils');
 const processor = require('../lib/processor');
 
 describe('Process', function () {
-    it('Can convert a single post', function () {
+    it('Can convert a single post', async function () {
         const fixture = testUtils.fixtures.readSync('single-post.json');
         const users = [];
         const options = {tags: true, addTag: null, featureImage: 'featuredmedia', url: 'https://mysite.com/bloob'};
-        const post = processor.processPost(fixture, users, options);
+        const post = await processor.processPost(fixture, users, options);
 
         post.should.be.an.Object().with.properties('url', 'data');
 
@@ -78,11 +78,11 @@ describe('Process', function () {
         data.website.should.eql('https://anothersite.com');
     });
 
-    it('Can convert a single page', function () {
+    it('Can convert a single page', async function () {
         const fixture = testUtils.fixtures.readSync('single-page.json');
         const users = null;
         const options = {tags: true, addTag: null, featureImage: 'featuredmedia', url: 'https://mysite.com'};
-        const page = processor.processPost(fixture, users, options);
+        const page = await processor.processPost(fixture, users, options);
 
         page.should.be.an.Object().with.properties('url', 'data');
 
@@ -105,11 +105,11 @@ describe('Process', function () {
         data.feature_image.should.eql('https://mysite.com/wp-content/uploads/2020/09/sample-image-scaled.jpg');
     });
 
-    it('Can convert a custom post type', function () {
+    it('Can convert a custom post type', async function () {
         const fixture = testUtils.fixtures.readSync('single-cpt-post.json');
         const users = [];
         const options = {tags: true, addTag: null, featureImage: 'featuredmedia', url: 'https://mysite.com', cpt: 'mycpt'};
-        const post = processor.processPost(fixture, users, options);
+        const post = await processor.processPost(fixture, users, options);
 
         const data = post.data;
 
@@ -124,11 +124,11 @@ describe('Process', function () {
         data.tags[6].data.name.should.eql('#mycpt');
     });
 
-    it('Can add a #wp-post tag when also converting a custom post type', function () {
+    it('Can add a #wp-post tag when also converting a custom post type', async function () {
         const fixture = testUtils.fixtures.readSync('single-post.json');
         const users = [];
         const options = {tags: true, addTag: null, featureImage: 'featuredmedia', url: 'https://mysite.com', cpt: 'mycpt'};
-        const post = processor.processPost(fixture, users, options);
+        const post = await processor.processPost(fixture, users, options);
 
         const data = post.data;
 
@@ -137,18 +137,18 @@ describe('Process', function () {
         data.tags[6].data.name.should.eql('#wp-post');
     });
 
-    it('Can remove first image in post if same as feature image', function () {
+    it('Can remove first image in post if same as feature image', async function () {
         const fixture = testUtils.fixtures.readSync('single-post-with-duplicate-images.json');
         const users = [];
         const options = {tags: true, addTag: null, featureImage: 'featuredmedia', url: 'https://mysite.com', cpt: 'mycpt'};
-        const post = processor.processPost(fixture, users, options);
+        const post = await processor.processPost(fixture, users, options);
 
         const data = post.data;
 
         data.html.should.eql('\n<h2><strong>This is my strong headline thing.</strong></h2>\n\n\n\n<p><em>Note: this article contains awesomeness</em></p>');
     });
 
-    it('Can use the first available author is none is set ', function () {
+    it('Can use the first available author is none is set ', async function () {
         const fixture = testUtils.fixtures.readSync('single-post-no-author.json');
         const users = [
             {
@@ -163,7 +163,7 @@ describe('Process', function () {
         ];
 
         const options = {tags: true, addTag: null, featureImage: 'featuredmedia', url: 'https://mysite.com'};
-        const post = processor.processPost(fixture, users, options);
+        const post = await processor.processPost(fixture, users, options);
 
         const data = post.data;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -348,6 +348,14 @@
     lodash "^4.17.21"
     uuid "^8.3.2"
 
+"@tryghost/errors@^0.2.13":
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/@tryghost/errors/-/errors-0.2.17.tgz#9b89f3845256ace5650593f41cc86d64965b56ed"
+  integrity sha512-Mj+bedWOwfooNA8fQdp6gIcRvWcKhJ/hOyGzu6OLFDLgEosFEeuFgXE6SsAWkf9+9NTYX30w88qGIWZqOhEAmQ==
+  dependencies:
+    "@tryghost/ignition-errors" "^0.1.0"
+    lodash "^4.17.21"
+
 "@tryghost/errors@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@tryghost/errors/-/errors-1.2.0.tgz#989f10434a17286e952b5a9434e50846ea4ad87c"
@@ -364,6 +372,14 @@
     "@tryghost/kg-parser-plugins" "^2.11.2"
     "@tryghost/mobiledoc-kit" "^0.12.4-ghost.1"
     jsdom "^18.0.0"
+
+"@tryghost/ignition-errors@^0.1.0":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@tryghost/ignition-errors/-/ignition-errors-0.1.8.tgz#6d4c4d4e02d32403ca1e574eaa91b3c0d138d6f6"
+  integrity sha512-4KYU+kDXZyP7tmzyHiUkfDy9RWxKAtA/6xTGdxYHurE5ZlT++cDDfdUtF0v3308GGUzKlBzRc3jmLjDYpngcBQ==
+  dependencies:
+    lodash "^4.17.21"
+    uuid "^8.3.2"
 
 "@tryghost/image-transform@1.0.26":
   version "1.0.26"


### PR DESCRIPTION
This allows us to scrape WordPress bookmark embeds, which uses an `iframe` to house its data that needs to be scraped.

It also lays the groundwork to allow async work within the processor, so remote data can be properly fetched and processed.