### PR TITLE
mg-jekyll-export: import catgories as "primary" tags.

### DIFF
--- a/packages/mg-jekyll-export/lib/process-post.js
+++ b/packages/mg-jekyll-export/lib/process-post.js
@@ -82,29 +82,8 @@ const processMeta = (fileName, markdown, options) => {
     // Add tags ^ categories from front matter
     // `tag` & `category` are interpreted as a single item
     // `tags` & `categories` are interpreted as a list of items
+    // `category` and `categories` are processed first so that they become the "primary tag"
     post.data.tags = [];
-
-    if (frontmatterAttributes.tag) {
-        post.data.tags.push({
-            url: `migrator-added-tag-${string.slugify(frontmatterAttributes.tag)}`,
-            data: {
-                name: frontmatterAttributes.tag,
-                slug: string.slugify(frontmatterAttributes.tag)
-            }
-        });
-    }
-
-    if (frontmatterAttributes.tags) {
-        frontmatterAttributes.tags.split(' ').forEach((tag) => {
-            post.data.tags.push({
-                url: `migrator-added-tag-${string.slugify(tag)}`,
-                data: {
-                    name: tag,
-                    slug: string.slugify(tag)
-                }
-            });
-        });
-    }
 
     if (frontmatterAttributes.category) {
         post.data.tags.push({
@@ -123,6 +102,28 @@ const processMeta = (fileName, markdown, options) => {
                 data: {
                     name: tag,
                     slug: `category-${string.slugify(tag)}`
+                }
+            });
+        });
+    }
+
+    if (frontmatterAttributes.tag) {
+        post.data.tags.push({
+            url: `migrator-added-tag-${string.slugify(frontmatterAttributes.tag)}`,
+            data: {
+                name: frontmatterAttributes.tag,
+                slug: string.slugify(frontmatterAttributes.tag)
+            }
+        });
+    }
+
+    if (frontmatterAttributes.tags) {
+        frontmatterAttributes.tags.split(' ').forEach((tag) => {
+            post.data.tags.push({
+                url: `migrator-added-tag-${string.slugify(tag)}`,
+                data: {
+                    name: tag,
+                    slug: string.slugify(tag)
                 }
             });
         });

--- a/packages/mg-jekyll-export/test/process.test.js
+++ b/packages/mg-jekyll-export/test/process.test.js
@@ -327,18 +327,6 @@ describe('Process', function () {
         post.data.tags.should.be.an.Array().with.lengthOf(8);
         post.data.tags.should.eql([
             {
-                url: 'migrator-added-tag-lorem-ipsum',
-                data: {name: 'Lorem Ipsum', slug: 'lorem-ipsum'}
-            },
-            {
-                url: 'migrator-added-tag-dolor',
-                data: {name: 'dolor', slug: 'dolor'}
-            },
-            {
-                url: 'migrator-added-tag-simet-amet',
-                data: {name: 'Simet-Amet', slug: 'simet-amet'}
-            },
-            {
                 url: 'migrator-added-tag-category-news',
                 data: {name: 'News', slug: 'category-news'}
             },
@@ -349,6 +337,18 @@ describe('Process', function () {
             {
                 url: 'migrator-added-tag-category-articles',
                 data: {name: 'Articles', slug: 'category-articles'}
+            },
+            {
+                url: 'migrator-added-tag-lorem-ipsum',
+                data: {name: 'Lorem Ipsum', slug: 'lorem-ipsum'}
+            },
+            {
+                url: 'migrator-added-tag-dolor',
+                data: {name: 'dolor', slug: 'dolor'}
+            },
+            {
+                url: 'migrator-added-tag-simet-amet',
+                data: {name: 'Simet-Amet', slug: 'simet-amet'}
             },
             {
                 url: 'migrator-added-tag',


### PR DESCRIPTION
Before, the first tag would have been imported first as the "primary tag".

Now, because the Ghost's "primary tag" is the best approximation of
Jekyll's "category", we import the "category first".
