### PR TITLE
Jekyll: Fix many bugs, add new features

### DIFF
--- a/packages/mg-jekyll-export/README.md
+++ b/packages/mg-jekyll-export/README.md
@@ -33,10 +33,11 @@ The `<path to zip file>` value should be the location of a zip file that has a s
 ```
 _posts/
 ├── 2020-10-27-my-post.md
-├── 2021-05-19-another-post.md
-└── 2022-06-03-newest-post.md
+├── 2021-05-19-another-post.markdown
+└── 2022-06-03-newest-post.html
+_drafts/
+└── 2022-06-03-some-draft.md
 ```
-
 It's possible to pass more options, in order to achieve a better migration file for Ghost:
 
 - **`-V` `--verbose`**

--- a/packages/mg-jekyll-export/README.md
+++ b/packages/mg-jekyll-export/README.md
@@ -61,7 +61,8 @@ It's possible to pass more options, in order to achieve a better migration file 
     - Provide an email domain for users e.g. example.com
 - **`--addTags`**
     - string - default: `null`
-    - Provide one or more tag names which should be added to every post in this migration
+    - Provide one or more tag names which should be added to every post in this migration.
+      This is addition to a '#jekyll' tag, which is always added.
 - **`--datedPermalinks`** 
     - Set the dated permalink structure
     - string - default: `none` 

--- a/packages/mg-jekyll-export/README.md
+++ b/packages/mg-jekyll-export/README.md
@@ -31,7 +31,7 @@ migrate jekyll <path to zip file>
 The `<path to zip file>` value should be the location of a zip file that has a structure like:
 
 ```
-posts/
+_posts/
 ├── 2020-10-27-my-post.md
 ├── 2021-05-19-another-post.md
 └── 2022-06-03-newest-post.md

--- a/packages/mg-jekyll-export/lib/process-html.js
+++ b/packages/mg-jekyll-export/lib/process-html.js
@@ -14,7 +14,10 @@ module.exports = (rawHtml, options = {}) => {
     // Convert relative links and image paths to absolute
     if (options.url) {
         const urlData = new URL(options.url);
-        const urlOrigin = urlData.href;
+        // The "origin" the URL truncated to the domain.
+        // The difference between the "href" matters for blogs that were hosted
+        // in sub-directories so that relative and relative-to-root URLs resolve correctly.
+        const urlOrigin = urlData.origin;
 
         $html('a').each((i, anchor) => {
             const thisURL = $(anchor).attr('href');

--- a/packages/mg-jekyll-export/lib/process-html.js
+++ b/packages/mg-jekyll-export/lib/process-html.js
@@ -1,14 +1,13 @@
-const MarkdownIt = require('markdown-it');
-const md = new MarkdownIt({
-    html: true
-});
-const fm = require('front-matter');
 const $ = require('cheerio');
 
-module.exports = (markdown, options = {}) => {
-    const frontmatter = fm(markdown);
-    const processedMarkdown = md.render(frontmatter.body);
-    const $html = $.load(processedMarkdown, {
+/*
+Process the HTML of a single Jekyll Post.
+
+Receives raw HTML, returns processed HTML
+*/
+
+module.exports = (rawHtml, options = {}) => {
+    const $html = $.load(rawHtml, {
         decodeEntities: false
     });
 

--- a/packages/mg-jekyll-export/lib/process-html.js
+++ b/packages/mg-jekyll-export/lib/process-html.js
@@ -20,7 +20,7 @@ module.exports = (rawHtml, options = {}) => {
             const thisURL = $(anchor).attr('href');
 
             // If it starts with a slash, append the base URL
-            if (thisURL.indexOf('/') === 0) {
+            if (thisURL && thisURL.indexOf('/') === 0) {
                 const updatedURL = `${urlOrigin.replace(/^\/|\/$/g, '')}/${thisURL.replace(/^\/|\/$/g, '')}`;
                 $(anchor).attr('href', updatedURL);
             }
@@ -30,7 +30,7 @@ module.exports = (rawHtml, options = {}) => {
             const thisSrc = $(img).attr('src');
 
             // If it starts with a slash, append the base URL
-            if (thisSrc.indexOf('/') === 0) {
+            if (thisSrc && thisSrc.indexOf('/') === 0) {
                 const updatedURL = `${urlOrigin.replace(/^\/|\/$/g, '')}/${thisSrc.replace(/^\/|\/$/g, '')}`;
                 $(img).attr('src', updatedURL);
             }

--- a/packages/mg-jekyll-export/lib/process-post.js
+++ b/packages/mg-jekyll-export/lib/process-post.js
@@ -3,7 +3,7 @@ const fm = require('front-matter');
 const processContent = require('./process-content');
 
 const processMeta = (fileName, markdown, options) => {
-    const isDraft = fileName.startsWith('drafts/');
+    const isDraft = fileName.startsWith('_drafts/');
 
     let frontmatter = fm(markdown);
     let frontmatterAttributes = frontmatter.attributes;
@@ -18,7 +18,7 @@ const processMeta = (fileName, markdown, options) => {
     const dateNow = new Date().toISOString();
 
     if (isDraft) {
-        const slugRegex = new RegExp('(drafts/)(.*).md');
+        const slugRegex = new RegExp('(_drafts/)(.*).(md|markdown)');
         slugParts = fileName.match(slugRegex);
         postSlug = slugParts[2];
     } else if (frontmatterAttributes.date) {
@@ -26,11 +26,11 @@ const processMeta = (fileName, markdown, options) => {
         const dateParts = frontmatterAttributes.date.match(frontMaterDateRegex);
         postDate = new Date(Date.UTC(dateParts[1], (dateParts[2] - 1), dateParts[3], 12, 0, 0)); // Months are zero-index, so 12 equals December
 
-        const slugRegex = new RegExp('([0-9a-zA-Z-_]+)/(.*).md');
+        const slugRegex = new RegExp('([0-9a-zA-Z-_]+)/(.*).(md|markdown)');
         slugParts = fileName.match(slugRegex);
         postSlug = slugParts[2];
     } else {
-        const datedSlugRegex = new RegExp('([0-9a-zA-Z-_]+)/([0-9]{4}-[0-9]{1,2}-[0-9]{1,2})-(.*).md');
+        const datedSlugRegex = new RegExp('([0-9a-zA-Z-_]+)/([0-9]{4}-[0-9]{1,2}-[0-9]{1,2})-(.*).(md|markdown)');
         slugParts = fileName.match(datedSlugRegex);
 
         if (slugParts[1] !== '_posts') {

--- a/packages/mg-jekyll-export/lib/process-post.js
+++ b/packages/mg-jekyll-export/lib/process-post.js
@@ -35,7 +35,7 @@ const processMeta = (fileName, fileContents, options) => {
     } else if (frontmatterAttributes.date) {
         const frontMaterDateRegex = new RegExp('([0-9]{4})[-:/\\ ]([0-9]{2})[-:/\\ ]([0-9]{2})');
         const dateParts = frontmatterAttributes.date.match(frontMaterDateRegex);
-        postDate = new Date(Date.UTC(dateParts[1], (dateParts[2] - 1), dateParts[3], 12, 0, 0)); // Months are zero-index, so 12 equals December
+        postDate = new Date(Date.UTC(dateParts[1], (dateParts[2] - 1), dateParts[3])); // Months are zero-index, so 11 equals December
 
         const slugRegex = new RegExp('([0-9a-zA-Z-_]+)/(.*).(md|markdown|html)');
         slugParts = fileName.match(slugRegex);
@@ -53,7 +53,7 @@ const processMeta = (fileName, fileContents, options) => {
         const dateYear = slugParts[2].split(/[-/]/)[0];
         const dateMonth = ('0' + slugParts[2].split(/[-/]/)[1]).slice(-2);
         const dateDay = ('0' + slugParts[2].split(/[-/]/)[2]).slice(-2);
-        postDate = new Date(Date.UTC(dateYear, (dateMonth - 1), dateDay, 12, 0, 0)); // Months are zero-index, so 12 equals December
+        postDate = new Date(Date.UTC(dateYear, (dateMonth - 1), dateDay)); // Months are zero-index, so 11 equals December
         postSlug = slugParts[3];
     }
 

--- a/packages/mg-jekyll-export/lib/process-post.js
+++ b/packages/mg-jekyll-export/lib/process-post.js
@@ -33,7 +33,7 @@ const processMeta = (fileName, markdown, options) => {
         const datedSlugRegex = new RegExp('([0-9a-zA-Z-_]+)/([0-9]{4}-[0-9]{1,2}-[0-9]{1,2})-(.*).md');
         slugParts = fileName.match(datedSlugRegex);
 
-        if (slugParts[1] !== 'posts') {
+        if (slugParts[1] !== '_posts') {
             postType = slugParts[1];
             nonStandardPostType = true;
         }

--- a/packages/mg-jekyll-export/lib/process-post.js
+++ b/packages/mg-jekyll-export/lib/process-post.js
@@ -105,7 +105,30 @@ const processMeta = (fileName, fileContents, options) => {
     // Add tags ^ categories from front matter
     // `tag` & `category` are interpreted as a single item
     // `tags` & `categories` are interpreted as a list of items
+    // `category` and `categories` are processed first so that they become the "primary tag"
     post.data.tags = [];
+
+    if (frontmatterAttributes.category) {
+        post.data.tags.push({
+            url: `migrator-added-tag-category-${string.slugify(frontmatterAttributes.category)}`,
+            data: {
+                name: frontmatterAttributes.category,
+                slug: `category-${string.slugify(frontmatterAttributes.category)}`
+            }
+        });
+    }
+
+    if (frontmatterAttributes.categories) {
+        frontmatterAttributes.categories.split(' ').forEach((tag) => {
+            post.data.tags.push({
+                url: `migrator-added-tag-category-${string.slugify(tag)}`,
+                data: {
+                    name: tag,
+                    slug: `category-${string.slugify(tag)}`
+                }
+            });
+        });
+    }
 
     if (frontmatterAttributes.tag) {
         post.data.tags.push({
@@ -132,28 +155,6 @@ const processMeta = (fileName, fileContents, options) => {
                 data: {
                     name: tag,
                     slug: string.slugify(tag)
-                }
-            });
-        });
-    }
-
-    if (frontmatterAttributes.category) {
-        post.data.tags.push({
-            url: `migrator-added-tag-category-${string.slugify(frontmatterAttributes.category)}`,
-            data: {
-                name: frontmatterAttributes.category,
-                slug: `category-${string.slugify(frontmatterAttributes.category)}`
-            }
-        });
-    }
-
-    if (frontmatterAttributes.categories) {
-        frontmatterAttributes.categories.split(' ').forEach((tag) => {
-            post.data.tags.push({
-                url: `migrator-added-tag-category-${string.slugify(tag)}`,
-                data: {
-                    name: tag,
-                    slug: `category-${string.slugify(tag)}`
                 }
             });
         });

--- a/packages/mg-jekyll-export/lib/process-post.js
+++ b/packages/mg-jekyll-export/lib/process-post.js
@@ -118,7 +118,15 @@ const processMeta = (fileName, fileContents, options) => {
     }
 
     if (frontmatterAttributes.tags) {
-        frontmatterAttributes.tags.split(' ').forEach((tag) => {
+        // Jekyll allows tags to be space separated or a YAML list. We support both cases.
+        let normalizedTags;
+        if (typeof frontmatterAttributes.tags === 'object') {
+            normalizedTags = frontmatterAttributes.tags;
+        } else {
+            normalizedTags = frontmatterAttributes.tags.split(' ');
+        }
+
+        normalizedTags.forEach((tag) => {
             post.data.tags.push({
                 url: `migrator-added-tag-${string.slugify(tag)}`,
                 data: {

--- a/packages/mg-jekyll-export/lib/process-post.js
+++ b/packages/mg-jekyll-export/lib/process-post.js
@@ -3,7 +3,7 @@ const fm = require('front-matter');
 const processContent = require('./process-content');
 
 const processMeta = (fileName, markdown, options) => {
-    const isDraft = fileName.startsWith('_drafts/');
+    const inDraftsDir = fileName.startsWith('_drafts/');
 
     let frontmatter = fm(markdown);
     let frontmatterAttributes = frontmatter.attributes;
@@ -17,7 +17,7 @@ const processMeta = (fileName, markdown, options) => {
     // Get an ISO 8601 date
     const dateNow = new Date().toISOString();
 
-    if (isDraft) {
+    if (inDraftsDir) {
         const slugRegex = new RegExp('(_drafts/)(.*).(md|markdown)');
         slugParts = fileName.match(slugRegex);
         postSlug = slugParts[2];
@@ -52,6 +52,8 @@ const processMeta = (fileName, markdown, options) => {
             slug: postSlug
         }
     };
+
+    const isDraft = (inDraftsDir || frontmatterAttributes.published === false);
 
     post.data.status = 'published';
     post.data.created_at = postDate || dateNow;

--- a/packages/mg-jekyll-export/lib/process-post.js
+++ b/packages/mg-jekyll-export/lib/process-post.js
@@ -33,10 +33,17 @@ const processMeta = (fileName, fileContents, options) => {
         slugParts = fileName.match(slugRegex);
         postSlug = slugParts[2];
     } else if (frontmatterAttributes.date) {
-        const frontMaterDateRegex = new RegExp('([0-9]{4})[-:/\\ ]([0-9]{2})[-:/\\ ]([0-9]{2})');
-        const dateParts = frontmatterAttributes.date.match(frontMaterDateRegex);
-        postDate = new Date(Date.UTC(dateParts[1], (dateParts[2] - 1), dateParts[3])); // Months are zero-index, so 11 equals December
+        // The date was unquoted in the frontmatter, it gets parsed into a data object
+        if (typeof frontmatterAttributes.date === 'object') {
+            postDate = frontmatterAttributes.date;
+        // Otherwise the date gets parsed as a string
+        } else {
+            const frontMaterDateRegex = new RegExp('([0-9]{4})[-:/\\ ]([0-9]{2})[-:/\\ ]([0-9]{2})');
+            // console.warn(`GOT ${typeof frontmatterAttributes.date}`)
 
+            const dateParts = frontmatterAttributes.date.match(frontMaterDateRegex);
+            postDate = new Date(Date.UTC(dateParts[1], (dateParts[2] - 1), dateParts[3])); // Months are zero-index, so 11 equals December
+        }
         const slugRegex = new RegExp('([0-9a-zA-Z-_]+)/(.*).(md|markdown|html)');
         slugParts = fileName.match(slugRegex);
         postSlug = slugParts[2];

--- a/packages/mg-jekyll-export/lib/process-post.js
+++ b/packages/mg-jekyll-export/lib/process-post.js
@@ -180,7 +180,7 @@ module.exports = (fileName, fileContents, globalUser = false, options = {}) => {
     } else if (isMarkdown) {
         rawHtml = md.render(post._body);
     } else {
-        throw new errors.GhostError({
+        throw new errors.InternalServerError({
             message: 'Unrecognized file extension. Only .md, .markdown and .html are supported'
         });
     }

--- a/packages/mg-jekyll-export/lib/process-post.js
+++ b/packages/mg-jekyll-export/lib/process-post.js
@@ -119,7 +119,15 @@ const processMeta = (fileName, fileContents, options) => {
     }
 
     if (frontmatterAttributes.categories) {
-        frontmatterAttributes.categories.split(' ').forEach((tag) => {
+        // Jekyll allows tags to be space separated or a YAML list. We support both cases.
+        let normalizedCats;
+        if (typeof frontmatterAttributes.categories === 'object') {
+            normalizedCats = frontmatterAttributes.categories;
+        } else {
+            normalizedCats = frontmatterAttributes.categories.split(' ');
+        }
+
+        normalizedCats.forEach((tag) => {
             post.data.tags.push({
                 url: `migrator-added-tag-category-${string.slugify(tag)}`,
                 data: {

--- a/packages/mg-jekyll-export/lib/process-post.js
+++ b/packages/mg-jekyll-export/lib/process-post.js
@@ -10,7 +10,7 @@ const processHtml = require('./process-html');
 /*
 Process both the frontmatter metadata and content of a single Jekyll Markdown post.
 
-The body may be ein Markdown or HTML.
+The body may be in Markdown or HTML.
 */
 
 const processMeta = (fileName, fileContents, options) => {

--- a/packages/mg-jekyll-export/lib/process.js
+++ b/packages/mg-jekyll-export/lib/process.js
@@ -16,7 +16,7 @@ module.exports = (input, options = {}) => {
     };
 
     if (input.posts && input.posts.length > 0) {
-        output.posts = input.posts.map(post => processPost(post.fileName, post.markdown, globalUser, options));
+        output.posts = input.posts.map(post => processPost(post.fileName, post.fileContents, globalUser, options));
     }
 
     return output;

--- a/packages/mg-jekyll-export/lib/read-zip.js
+++ b/packages/mg-jekyll-export/lib/read-zip.js
@@ -12,12 +12,12 @@ module.exports = (zipPath, options) => {
     // - _posts
     //   - 2020-10-27-my-post.md
     //   - 2021-05-19-2020-was-quite-a-year.md
-    // The file extension may be ".md" or ".markdown"
+    // The file extension may be ".md", ".markdown" or ".html"
     fsUtils.zip.read(zipPath, (entryName, zipEntry) => {
-        if (/^_posts\/.*\.(md|markdown)$/.test(entryName)) {
+        if (/^_posts\/.*\.(md|markdown|html)$/.test(entryName)) {
             content.posts.push({
                 fileName: entryName,
-                markdown: zipEntry.getData().toString('utf8')
+                fileContents: zipEntry.getData().toString('utf8')
             });
 
         // Skip if not matched above, and report skipped files if `--verbose`

--- a/packages/mg-jekyll-export/lib/read-zip.js
+++ b/packages/mg-jekyll-export/lib/read-zip.js
@@ -1,3 +1,4 @@
+const errors = require('@tryghost/errors');
 const fsUtils = require('@tryghost/mg-fs-utils');
 const ui = require('@tryghost/pretty-cli').ui;
 

--- a/packages/mg-jekyll-export/lib/read-zip.js
+++ b/packages/mg-jekyll-export/lib/read-zip.js
@@ -15,7 +15,11 @@ module.exports = (zipPath, options) => {
     //   - 2021-05-19-2020-was-quite-a-year.md
     // The file extension may be ".md", ".markdown" or ".html"
     fsUtils.zip.read(zipPath, (entryName, zipEntry) => {
-        if (/^_posts\/.*\.(md|markdown|html)$/.test(entryName)) {
+        // The `entryName` arg here lacks the directory name.
+        // We need zipEntry.entryName instead, which contains it.
+        entryName = zipEntry.entryName;
+
+        if (/^_(posts|drafts)\/.*\.(md|markdown|html)$/.test(entryName)) {
             content.posts.push({
                 fileName: entryName,
                 fileContents: zipEntry.getData().toString('utf8')
@@ -24,7 +28,7 @@ module.exports = (zipPath, options) => {
         // Skip if not matched above, and report skipped files if `--verbose`
         } else {
             if (options.verbose) {
-                ui.log.info('Skipped: ' + entryName);
+                ui.log.info('Skipped: ' + zipEntry.entryName);
             }
             skippedFileCount += 1;
         }

--- a/packages/mg-jekyll-export/lib/read-zip.js
+++ b/packages/mg-jekyll-export/lib/read-zip.js
@@ -14,7 +14,6 @@ module.exports = (zipPath, options) => {
     //   - 2021-05-19-2020-was-quite-a-year.md
 
     fsUtils.zip.read(zipPath, (entryName, zipEntry) => {
-        // Catch all HTML files inside `profile/`
         if (/^_posts\/.*\.md$/.test(entryName)) {
             content.posts.push({
                 fileName: entryName,

--- a/packages/mg-jekyll-export/lib/read-zip.js
+++ b/packages/mg-jekyll-export/lib/read-zip.js
@@ -32,5 +32,10 @@ module.exports = (zipPath, options) => {
 
     ui.log.info('Skipped files: ' + skippedFileCount);
 
+    if (!content.posts.length) {
+        ui.log.error('No content found to import! Quitting.');
+        throw new errors.InternalServerError();
+    }
+
     return content;
 };

--- a/packages/mg-jekyll-export/lib/read-zip.js
+++ b/packages/mg-jekyll-export/lib/read-zip.js
@@ -9,13 +9,13 @@ module.exports = (zipPath, options) => {
     let skippedFileCount = 0;
 
     // We only support the current Jekyll export file structure:
-    // - posts
+    // - _posts
     //   - 2020-10-27-my-post.md
     //   - 2021-05-19-2020-was-quite-a-year.md
 
     fsUtils.zip.read(zipPath, (entryName, zipEntry) => {
         // Catch all HTML files inside `profile/`
-        if (/^posts\/.*\.md$/.test(entryName)) {
+        if (/^_posts\/.*\.md$/.test(entryName)) {
             content.posts.push({
                 fileName: entryName,
                 markdown: zipEntry.getData().toString('utf8')

--- a/packages/mg-jekyll-export/lib/read-zip.js
+++ b/packages/mg-jekyll-export/lib/read-zip.js
@@ -12,9 +12,9 @@ module.exports = (zipPath, options) => {
     // - _posts
     //   - 2020-10-27-my-post.md
     //   - 2021-05-19-2020-was-quite-a-year.md
-
+    // The file extension may be ".md" or ".markdown"
     fsUtils.zip.read(zipPath, (entryName, zipEntry) => {
-        if (/^_posts\/.*\.md$/.test(entryName)) {
+        if (/^_posts\/.*\.(md|markdown)$/.test(entryName)) {
             content.posts.push({
                 fileName: entryName,
                 markdown: zipEntry.getData().toString('utf8')

--- a/packages/mg-jekyll-export/package.json
+++ b/packages/mg-jekyll-export/package.json
@@ -25,6 +25,7 @@
     "sinon": "14.0.0"
   },
   "dependencies": {
+    "@tryghost/errors": "^1.2.14",
     "@tryghost/mg-fs-utils": "^0.8.2",
     "@tryghost/string": "^0.1.17",
     "cheerio": "0.22.0",

--- a/packages/mg-jekyll-export/test/fixtures/2021-08-25-relative-links.md
+++ b/packages/mg-jekyll-export/test/fixtures/2021-08-25-relative-links.md
@@ -7,6 +7,8 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. [Pellentesque rutrum](/
 
 ![A nice photo](/images/photo.jpg)
 
+![Relative-to-root image](/news/images/photo.jpg)
+
 Duis efficitur nisl pharetra enim lobortis consequat. Curabitur vestibulum diam vel elit ultricies semper.
 
 ![Another nice photo](http://example.com/images/photo.jpg)

--- a/packages/mg-jekyll-export/test/fixtures/2022-06-05-basic.html
+++ b/packages/mg-jekyll-export/test/fixtures/2022-06-05-basic.html
@@ -1,0 +1,8 @@
+---
+title: Basic HTML Post
+author: Mark Stosberg
+---
+<p>First Paragraph</p>
+
+* First
+* Second

--- a/packages/mg-jekyll-export/test/fixtures/2022-06-05-published-false.md
+++ b/packages/mg-jekyll-export/test/fixtures/2022-06-05-published-false.md
@@ -1,0 +1,7 @@
+---
+title: "This post has published:false set"
+author: Mark Stosberg
+published: false
+---
+
+Nothing interesting here.

--- a/packages/mg-jekyll-export/test/fixtures/2022-06-06-tag-list.md
+++ b/packages/mg-jekyll-export/test/fixtures/2022-06-06-tag-list.md
@@ -1,0 +1,7 @@
+---
+title: "This post as tags as a YAML list"
+tags: [some-word]
+categories: [cat, photos]
+---
+
+Issue #512

--- a/packages/mg-jekyll-export/test/fixtures/2022-06-09-basename.md
+++ b/packages/mg-jekyll-export/test/fixtures/2022-06-09-basename.md
@@ -1,7 +1,6 @@
 ---
-title: "This post as tags as a YAML list"
-tags: [some-word]
-categories: [cat, photos]
+title: "This post has 'basename' frontmatter"
+basename: custom-basename
 ---
 
-Issue #512
+Issue #504

--- a/packages/mg-jekyll-export/test/fixtures/2022-06-09-basename.md
+++ b/packages/mg-jekyll-export/test/fixtures/2022-06-09-basename.md
@@ -1,0 +1,7 @@
+---
+title: "This post as tags as a YAML list"
+tags: [some-word]
+categories: [cat, photos]
+---
+
+Issue #512

--- a/packages/mg-jekyll-export/test/fixtures/unquoted-date.markdown
+++ b/packages/mg-jekyll-export/test/fixtures/unquoted-date.markdown
@@ -1,0 +1,10 @@
+---
+date: 2022-06-06
+title: "Unquoted Date"
+author: "Mark Stosberg"
+---
+
+The frontmatter "date" has no strings around it.
+
+This will get parsed directly into a date object instead of a string.
+

--- a/packages/mg-jekyll-export/test/process.test.js
+++ b/packages/mg-jekyll-export/test/process.test.js
@@ -16,9 +16,9 @@ describe('Process', function () {
         post.data.type.should.eql('post');
         post.data.status.should.eql('published');
 
-        post.data.created_at.toISOString().should.eql('2021-08-23T12:00:00.000Z');
-        post.data.published_at.toISOString().should.eql('2021-08-23T12:00:00.000Z');
-        post.data.updated_at.toISOString().should.eql('2021-08-23T12:00:00.000Z');
+        post.data.created_at.toISOString().should.eql('2021-08-23T00:00:00.000Z');
+        post.data.published_at.toISOString().should.eql('2021-08-23T00:00:00.000Z');
+        post.data.updated_at.toISOString().should.eql('2021-08-23T00:00:00.000Z');
 
         post.data.tags[0].url.should.eql('migrator-added-tag');
         post.data.tags[0].data.name.should.eql('#jekyll');
@@ -166,9 +166,9 @@ describe('Process', function () {
         const fixture = testUtils.fixtures.readSync('2021-9-1-alt-date-format.md');
         const post = processPost(fakeName, fixture);
 
-        post.data.created_at.toISOString().should.eql('2021-09-01T12:00:00.000Z');
-        post.data.published_at.toISOString().should.eql('2021-09-01T12:00:00.000Z');
-        post.data.updated_at.toISOString().should.eql('2021-09-01T12:00:00.000Z');
+        post.data.created_at.toISOString().should.eql('2021-09-01T00:00:00.000Z');
+        post.data.published_at.toISOString().should.eql('2021-09-01T00:00:00.000Z');
+        post.data.updated_at.toISOString().should.eql('2021-09-01T00:00:00.000Z');
     });
 
     it('Can use a supplied email domain for auhtors', function () {
@@ -275,9 +275,9 @@ describe('Process', function () {
         post.data.type.should.eql('post');
         post.data.status.should.eql('published');
 
-        post.data.created_at.toISOString().should.eql('2021-11-26T12:00:00.000Z');
-        post.data.published_at.toISOString().should.eql('2021-11-26T12:00:00.000Z');
-        post.data.updated_at.toISOString().should.eql('2021-11-26T12:00:00.000Z');
+        post.data.created_at.toISOString().should.eql('2021-11-26T00:00:00.000Z');
+        post.data.published_at.toISOString().should.eql('2021-11-26T00:00:00.000Z');
+        post.data.updated_at.toISOString().should.eql('2021-11-26T00:00:00.000Z');
 
         post.data.tags[0].url.should.eql('migrator-added-tag');
         post.data.tags[0].data.slug.should.eql('hash-jekyll');

--- a/packages/mg-jekyll-export/test/process.test.js
+++ b/packages/mg-jekyll-export/test/process.test.js
@@ -5,7 +5,7 @@ const testUtils = require('./utils');
 const processPost = require('../lib/process-post');
 
 describe('Process', function () {
-    it('Can process a basic Jekyll post', function () {
+    it('Can process a basic Jekyll Markdown post', function () {
         const fakeName = '_posts/2021-08-23-basic-post.md';
         const fixture = testUtils.fixtures.readSync('2021-08-23-basic-post.md');
         const post = processPost(fakeName, fixture);
@@ -74,6 +74,21 @@ describe('Process', function () {
         post.data.author.data.name.should.eql('Persons Name');
         post.data.author.data.slug.should.eql('persons-name');
         post.data.author.data.roles[0].should.eql('Contributor');
+    });
+
+    it('Can process a basic Jekyll HTML post', function () {
+        const fakeName = '_posts/2022-06-05-basic.html';
+        const fixture = testUtils.fixtures.readSync('2022-06-05-basic.html');
+        const post = processPost(fakeName, fixture);
+
+        post.data.title.should.eql('Basic HTML Post');
+
+        // Here are testing that Markdown syntax is left alone
+        post.data.html.should.eql('<p>First Paragraph</p>\n' +
+            '\n' +
+            '* First\n' +
+            '* Second');
+        post.data.author.data.name.should.eql('Mark Stosberg');
     });
 
     it('Can process a basic Jekyll post with no author', function () {

--- a/packages/mg-jekyll-export/test/process.test.js
+++ b/packages/mg-jekyll-export/test/process.test.js
@@ -197,6 +197,15 @@ describe('Process', function () {
         post.data.status.should.eql('draft');
     });
 
+    it('Can process published:false frontmatter', function () {
+        const fakeName = '_posts/2022-06-05-published-false.md';
+        const fixture = testUtils.fixtures.readSync('2022-06-05-published-false.md');
+        const post = processPost(fakeName, fixture);
+
+        post.data.type.should.eql('post');
+        post.data.status.should.eql('draft');
+    });
+
     it('Can process non-standard post types and add related tag', function () {
         const fakeName = 'w31rd_type-here/2021-08-25-relative-links.md';
         const fixture = testUtils.fixtures.readSync('2021-08-25-relative-links.md');

--- a/packages/mg-jekyll-export/test/process.test.js
+++ b/packages/mg-jekyll-export/test/process.test.js
@@ -288,6 +288,16 @@ describe('Process', function () {
         post.data.tags[1].data.name.should.eql('NoFileDate');
     });
 
+    it('Can process posts with unquoted date in frontmatter, using .markdown extension', function () {
+        const fakeName = '_posts/unquoted-date.markdown';
+        const fixture = testUtils.fixtures.readSync('unquoted-date.markdown');
+        const post = processPost(fakeName, fixture, false);
+
+        post.data.created_at.toISOString().should.eql('2022-06-06T00:00:00.000Z');
+        post.data.published_at.toISOString().should.eql('2022-06-06T00:00:00.000Z');
+        post.data.updated_at.toISOString().should.eql('2022-06-06T00:00:00.000Z');
+    });
+
     it('Can process posts that already include HTML', function () {
         const fakeName = '_posts/2022-03-10-has-html.md';
         const fixture = testUtils.fixtures.readSync('2022-03-10-has-html.md');

--- a/packages/mg-jekyll-export/test/process.test.js
+++ b/packages/mg-jekyll-export/test/process.test.js
@@ -120,6 +120,7 @@ describe('Process', function () {
 
         post.data.html.should.eql('<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. <a href="/another-page">Pellentesque rutrum</a> ante in <a href="https://example.com">sapien ultrices</a>, sit amet auctor tellus iaculis.</p>\n' +
             '<p><img src="/images/photo.jpg" alt="A nice photo"></p>\n' +
+            '<p><img src="/news/images/photo.jpg" alt="Relative-to-root image"></p>\n' +
             '<p>Duis efficitur nisl pharetra enim lobortis consequat. Curabitur vestibulum diam vel elit ultricies semper.</p>\n' +
             '<p><img src="http://example.com/images/photo.jpg" alt="Another nice photo"></p>\n' +
             '<p>Sed nec sagittis risus, vitae tempor mi. Suspendisse potenti.</p>');
@@ -136,6 +137,7 @@ describe('Process', function () {
 
         post.data.html.should.eql('<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. <a href="https://www.my-site.com/another-page">Pellentesque rutrum</a> ante in <a href="https://example.com">sapien ultrices</a>, sit amet auctor tellus iaculis.</p>\n' +
             '<p><img src="https://www.my-site.com/images/photo.jpg" alt="A nice photo"></p>\n' +
+            '<p><img src="https://www.my-site.com/news/images/photo.jpg" alt="Relative-to-root image"></p>\n' +
             '<p>Duis efficitur nisl pharetra enim lobortis consequat. Curabitur vestibulum diam vel elit ultricies semper.</p>\n' +
             '<p><img src="http://example.com/images/photo.jpg" alt="Another nice photo"></p>\n' +
             '<p>Sed nec sagittis risus, vitae tempor mi. Suspendisse potenti.</p>');
@@ -152,8 +154,9 @@ describe('Process', function () {
             }
         );
 
-        post.data.html.should.eql('<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. <a href="https://blog.my-site.com/news/another-page">Pellentesque rutrum</a> ante in <a href="https://example.com">sapien ultrices</a>, sit amet auctor tellus iaculis.</p>\n' +
-            '<p><img src="https://blog.my-site.com/news/images/photo.jpg" alt="A nice photo"></p>\n' +
+        post.data.html.should.eql('<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. <a href="https://blog.my-site.com/another-page">Pellentesque rutrum</a> ante in <a href="https://example.com">sapien ultrices</a>, sit amet auctor tellus iaculis.</p>\n' +
+            '<p><img src="https://blog.my-site.com/images/photo.jpg" alt="A nice photo"></p>\n' +
+            '<p><img src="https://blog.my-site.com/news/images/photo.jpg" alt="Relative-to-root image"></p>\n' +
             '<p>Duis efficitur nisl pharetra enim lobortis consequat. Curabitur vestibulum diam vel elit ultricies semper.</p>\n' +
             '<p><img src="http://example.com/images/photo.jpg" alt="Another nice photo"></p>\n' +
             '<p>Sed nec sagittis risus, vitae tempor mi. Suspendisse potenti.</p>');
@@ -171,7 +174,7 @@ describe('Process', function () {
         post.data.updated_at.toISOString().should.eql('2021-09-01T00:00:00.000Z');
     });
 
-    it('Can use a supplied email domain for auhtors', function () {
+    it('Can use a supplied email domain for authors', function () {
         const fakeName = '_posts/2021-08-25-relative-links.md';
         const fixture = testUtils.fixtures.readSync('2021-08-25-relative-links.md');
         const post = processPost(fakeName, fixture, false, {

--- a/packages/mg-jekyll-export/test/process.test.js
+++ b/packages/mg-jekyll-export/test/process.test.js
@@ -224,6 +224,14 @@ describe('Process', function () {
         post.data.status.should.eql('draft');
     });
 
+    it('Can process `basename` frontmatter into slug', function () {
+        const fakeName = '_posts/2022-06-09-basename.md';
+        const fixture = testUtils.fixtures.readSync('2022-06-09-basename.md');
+        const post = processPost(fakeName, fixture);
+
+        post.data.slug.should.eql('custom-basename');
+    });
+
     it('Can process non-standard post types and add related tag', function () {
         const fakeName = 'w31rd_type-here/2021-08-25-relative-links.md';
         const fixture = testUtils.fixtures.readSync('2021-08-25-relative-links.md');

--- a/packages/mg-jekyll-export/test/process.test.js
+++ b/packages/mg-jekyll-export/test/process.test.js
@@ -6,7 +6,7 @@ const processPost = require('../lib/process-post');
 
 describe('Process', function () {
     it('Can process a basic Jekyll post', function () {
-        const fakeName = 'posts/2021-08-23-basic-post.md';
+        const fakeName = '_posts/2021-08-23-basic-post.md';
         const fixture = testUtils.fixtures.readSync('2021-08-23-basic-post.md');
         const post = processPost(fakeName, fixture);
 
@@ -77,7 +77,7 @@ describe('Process', function () {
     });
 
     it('Can process a basic Jekyll post with no author', function () {
-        const fakeName = 'posts/2021-08-24-no-author.md';
+        const fakeName = '_posts/2021-08-24-no-author.md';
         const fixture = testUtils.fixtures.readSync('2021-08-24-no-author.md');
         const post = processPost(fakeName, fixture,
             {
@@ -99,7 +99,7 @@ describe('Process', function () {
     });
 
     it('Can leave relative links when no URL is defined', function () {
-        const fakeName = 'posts/2021-08-25-relative-links.md';
+        const fakeName = '_posts/2021-08-25-relative-links.md';
         const fixture = testUtils.fixtures.readSync('2021-08-25-relative-links.md');
         const post = processPost(fakeName, fixture);
 
@@ -111,7 +111,7 @@ describe('Process', function () {
     });
 
     it('Can fix relative links when a URL is defined', function () {
-        const fakeName = 'posts/2021-08-25-relative-links.md';
+        const fakeName = '_posts/2021-08-25-relative-links.md';
         const fixture = testUtils.fixtures.readSync('2021-08-25-relative-links.md');
         const post = processPost(fakeName, fixture, false,
             {
@@ -129,7 +129,7 @@ describe('Process', function () {
     });
 
     it('Can fix relative links when a URL with subdirectory is defined', function () {
-        const fakeName = 'posts/2021-08-25-relative-links.md';
+        const fakeName = '_posts/2021-08-25-relative-links.md';
         const fixture = testUtils.fixtures.readSync('2021-08-25-relative-links.md');
         const post = processPost(fakeName, fixture, false,
             {
@@ -147,7 +147,7 @@ describe('Process', function () {
     });
 
     it('Can use a non-standard post date format', function () {
-        const fakeName = 'posts/2021-9-1-alt-date-format.md';
+        const fakeName = '_posts/2021-9-1-alt-date-format.md';
         const fixture = testUtils.fixtures.readSync('2021-9-1-alt-date-format.md');
         const post = processPost(fakeName, fixture);
 
@@ -157,7 +157,7 @@ describe('Process', function () {
     });
 
     it('Can use a supplied email domain for auhtors', function () {
-        const fakeName = 'posts/2021-08-25-relative-links.md';
+        const fakeName = '_posts/2021-08-25-relative-links.md';
         const fixture = testUtils.fixtures.readSync('2021-08-25-relative-links.md');
         const post = processPost(fakeName, fixture, false, {
             email: 'company.com'
@@ -167,7 +167,7 @@ describe('Process', function () {
     });
 
     it('Can add specified tags to each post', function () {
-        const fakeName = 'posts/2021-08-25-relative-links.md';
+        const fakeName = '_posts/2021-08-25-relative-links.md';
         const fixture = testUtils.fixtures.readSync('2021-08-25-relative-links.md');
         const post = processPost(fakeName, fixture, false, {
             addTags: 'Hello,  #World'
@@ -242,7 +242,7 @@ describe('Process', function () {
     });
 
     it('Can process posts without a date in the file name', function () {
-        const fakeName = 'posts/my-first-post.md';
+        const fakeName = '_posts/my-first-post.md';
         const fixture = testUtils.fixtures.readSync('my-first-post.md');
         const post = processPost(fakeName, fixture, false, {
             addTags: 'NoFileDate'
@@ -265,7 +265,7 @@ describe('Process', function () {
     });
 
     it('Can process posts that already include HTML', function () {
-        const fakeName = 'posts/2022-03-10-has-html.md';
+        const fakeName = '_posts/2022-03-10-has-html.md';
         const fixture = testUtils.fixtures.readSync('2022-03-10-has-html.md');
         const post = processPost(fakeName, fixture, false, {
             addTags: 'Has HTML'
@@ -280,7 +280,7 @@ describe('Process', function () {
     });
 
     it('Can process lists that have spaced between list items', function () {
-        const fakeName = 'posts/2022-03-11-has-spaced-lists.md';
+        const fakeName = '_posts/2022-03-11-has-spaced-lists.md';
         const fixture = testUtils.fixtures.readSync('2022-03-11-has-spaced-lists.md');
         const post = processPost(fakeName, fixture, false, {
             addTags: 'Has HTML'
@@ -318,7 +318,7 @@ describe('Process', function () {
     });
 
     it('Can process front matter tags & categories', function () {
-        const fakeName = 'posts/2022-06-03-front-matter-tags-cats.md';
+        const fakeName = '_posts/2022-06-03-front-matter-tags-cats.md';
         const fixture = testUtils.fixtures.readSync('2022-06-03-front-matter-tags-cats.md');
         const post = processPost(fakeName, fixture, false, {
             addTags: 'My Extra Tag'

--- a/packages/mg-jekyll-export/test/process.test.js
+++ b/packages/mg-jekyll-export/test/process.test.js
@@ -298,6 +298,13 @@ describe('Process', function () {
         post.data.updated_at.toISOString().should.eql('2022-06-06T00:00:00.000Z');
     });
 
+    it('Can process posts with tags in YAML list format', function () {
+        const fakeName = '_posts/2022-06-06-tag-list.md';
+        const fixture = testUtils.fixtures.readSync('2022-06-06-tag-list.md');
+        const post = processPost(fakeName, fixture, false);
+
+        post.data.tags[0].data.slug.should.eql('some-word');
+    });
     it('Can process posts that already include HTML', function () {
         const fakeName = '_posts/2022-03-10-has-html.md';
         const fixture = testUtils.fixtures.readSync('2022-03-10-has-html.md');

--- a/packages/mg-jekyll-export/test/process.test.js
+++ b/packages/mg-jekyll-export/test/process.test.js
@@ -298,12 +298,16 @@ describe('Process', function () {
         post.data.updated_at.toISOString().should.eql('2022-06-06T00:00:00.000Z');
     });
 
-    it('Can process posts with tags in YAML list format', function () {
+    it('Can process posts with tags and categories in YAML list format', function () {
         const fakeName = '_posts/2022-06-06-tag-list.md';
         const fixture = testUtils.fixtures.readSync('2022-06-06-tag-list.md');
         const post = processPost(fakeName, fixture, false);
 
-        post.data.tags[0].data.slug.should.eql('some-word');
+        post.data.tags[0].data.name.should.eql('cat');
+        post.data.tags[0].data.slug.should.eql('category-cat');
+        post.data.tags[1].data.name.should.eql('photos');
+        post.data.tags[1].data.slug.should.eql('category-photos');
+        post.data.tags[2].data.slug.should.eql('some-word');
     });
     it('Can process posts that already include HTML', function () {
         const fakeName = '_posts/2022-03-10-has-html.md';

--- a/packages/mg-jekyll-export/test/process.test.js
+++ b/packages/mg-jekyll-export/test/process.test.js
@@ -368,18 +368,6 @@ describe('Process', function () {
         post.data.tags.should.be.an.Array().with.lengthOf(8);
         post.data.tags.should.eql([
             {
-                url: 'migrator-added-tag-lorem-ipsum',
-                data: {name: 'Lorem Ipsum', slug: 'lorem-ipsum'}
-            },
-            {
-                url: 'migrator-added-tag-dolor',
-                data: {name: 'dolor', slug: 'dolor'}
-            },
-            {
-                url: 'migrator-added-tag-simet-amet',
-                data: {name: 'Simet-Amet', slug: 'simet-amet'}
-            },
-            {
                 url: 'migrator-added-tag-category-news',
                 data: {name: 'News', slug: 'category-news'}
             },
@@ -390,6 +378,18 @@ describe('Process', function () {
             {
                 url: 'migrator-added-tag-category-articles',
                 data: {name: 'Articles', slug: 'category-articles'}
+            },
+            {
+                url: 'migrator-added-tag-lorem-ipsum',
+                data: {name: 'Lorem Ipsum', slug: 'lorem-ipsum'}
+            },
+            {
+                url: 'migrator-added-tag-dolor',
+                data: {name: 'dolor', slug: 'dolor'}
+            },
+            {
+                url: 'migrator-added-tag-simet-amet',
+                data: {name: 'Simet-Amet', slug: 'simet-amet'}
             },
             {
                 url: 'migrator-added-tag',

--- a/packages/mg-jekyll-export/test/process.test.js
+++ b/packages/mg-jekyll-export/test/process.test.js
@@ -189,7 +189,7 @@ describe('Process', function () {
     });
 
     it('Can process draft posts', function () {
-        const fakeName = 'drafts/relative-links.md';
+        const fakeName = '_drafts/relative-links.md';
         const fixture = testUtils.fixtures.readSync('2021-08-25-relative-links.md');
         const post = processPost(fakeName, fixture);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -333,6 +333,15 @@
     utils-copy-error "^1.0.1"
     uuid "^8.3.2"
 
+"@tryghost/errors@^1.2.14":
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/@tryghost/errors/-/errors-1.2.14.tgz#af5e0ea1450b6fac7bde94585177943f85f0e41f"
+  integrity sha512-ycXhblMBlbwXo+PfmVJZtT26/B1wu6Ae/8SBjXlzHAp6qlkho/Z5hZPKMRo0frfBt6CDGyX/abKTeVQzSkTPYA==
+  dependencies:
+    lodash "^4.17.21"
+    utils-copy-error "^1.0.1"
+    uuid "^8.3.2"
+
 "@tryghost/html-to-mobiledoc@1.8.6":
   version "1.8.6"
   resolved "https://registry.yarnpkg.com/@tryghost/html-to-mobiledoc/-/html-to-mobiledoc-1.8.6.tgz#8c253fde1e0bbaa15fd427dfe89a5a505ca70ef9"


### PR DESCRIPTION
**UPDATE:** This PR was originally about the narrow scope of fixing the bug below. But I soon ran into a number other bugs and missing features that affected the same parts of the code. It quickly became not feasible to submit separate PRs for them, as many would overlap would conflict, so this PR collects all the fixes I've made. Looking at the individual commits will provide context for each change. 

-----
Bug: "Should import _posts, not "posts""

The Jekyll docs are clear that posts go in "\_posts" (with an
underscore):

https://jekyllrb.com/docs/structure/

While "posts" (no underscore) may be the the name of an output directory
with rendered HTML.

Because HTML is also valid as an impout format, importing "posts" is
no longer supported to avoid confusion.
