### PR TITLE
Accept storage adapter to save final revue files to

### DIFF
--- a/packages/mg-fs-utils/lib/zip.js
+++ b/packages/mg-fs-utils/lib/zip.js
@@ -1,6 +1,6 @@
 import {join} from 'node:path';
 import AdmZip from 'adm-zip';
-import {ensureDirSync} from 'fs-extra';
+import {ensureDirSync, remove, ensureFileSync} from 'fs-extra';
 import zip from '@tryghost/zip';
 import errors from '@tryghost/errors';
 
@@ -44,7 +44,7 @@ const read = (zipPath, callback) => {
 };
 
 const write = async (zipPath, contentFolder, fileName) => {
-    // Ensure the directory we want to wite to exists
+    // Ensure the directory we want to write to exists
     ensureDirSync(zipPath);
 
     const outputPath = join(zipPath, fileName || `ghost-import-${Date.now()}.zip`);
@@ -52,8 +52,15 @@ const write = async (zipPath, contentFolder, fileName) => {
     return await zip.compress(contentFolder, outputPath);
 };
 
+const deleteFile = async (fileToDelete) => {
+    ensureFileSync(fileToDelete);
+
+    return await remove(fileToDelete);
+};
+
 export default {
     read,
     write,
-    _private
+    _private,
+    deleteFile
 };


### PR DESCRIPTION
refs https://www.notion.so/ghost/Import-3d06dfb3acf74ea3b412eab2abd1edf8

- Allow passing in a storage adapter instead of a final output path for Revue migrations
- When a property `outputStorage` is passed in and a valid fn, we do the following steps
    1. still generate the zip file and save it in the given output dir
    2. read the buffer of the zip file and pass it to the `upload` method of the storage adapter
    3. delete the zip file from the local output dir, once upload was successful
   

Pretty sure there's still some clean up to do, which I haven't had the knowledge of, but you get the idea. 