### PR TITLE
Added more verbose information to the CLI commands

### DIFF
--- a/packages/mg-stripe/src/lib/DelayPrompt.ts
+++ b/packages/mg-stripe/src/lib/DelayPrompt.ts
@@ -1,0 +1,27 @@
+import Logger from './Logger.js';
+import input from '@inquirer/input';
+import chalk from 'chalk';
+
+export class DelayPrompt {
+    async ask(delayOpt?: number): Promise<number> {
+        if (delayOpt && Number.isInteger(delayOpt) && delayOpt > 1) {
+            return delayOpt;
+        }
+
+        Logger.shared.info(`We recommend ${chalk.cyan('delaying payment collection')} from Stripe until the copy is finished, to avoid duplicate charges.`);
+        Logger.shared.info(`As a rule of thumb, copying 10,000 subscriptions takes roughly an hour. We suggest adding an hour of buffer time to be safe.`);
+
+        const delayInput = await input({
+            message: 'For how many hours would you like to pause payment collection?'
+        });
+
+        const delay = parseInt(delayInput, 10);
+
+        if (!Number.isInteger(delay) || delay < 1) {
+            Logger.shared.fail('Expected a delay in payment collection of at least 1 hour.');
+            process.exit(1);
+        }
+
+        return delay;
+    }
+}

--- a/packages/mg-stripe/src/lib/Options.ts
+++ b/packages/mg-stripe/src/lib/Options.ts
@@ -7,25 +7,25 @@ export class Options {
             type: 'boolean',
             flags: '--dry-run',
             defaultValue: false,
-            desc: 'Run the import without actually creating any subscriptions'
+            desc: 'Dry run a copy, without actually creating any data object in the new account (optional)'
         },
         {
             type: 'string',
             flags: '--from',
             defaultValue: false,
-            desc: 'The Stripe API key of the old account (optional)'
+            desc: 'The Stripe API secret key of the old account (optional)'
         },
         {
             type: 'string',
             flags: '--to',
             defaultValue: false,
-            desc: 'The Stripe API key of the new account (optional)'
+            desc: 'The Stripe API secret key of the new account (optional)'
         },
         {
             type: 'number',
             flags: '--delay',
             defaultValue: 12,
-            desc: 'Period in hours in which newly created subscriptions won\'t create any charges (subscriptions that expire in this period will be delayed a bit). Within this period you should be able to confirm the migration or revert it. Defaults to 12.'
+            desc: 'Period (in hours, starting now) during which payment collection is paused. This period should be large enough to perform the entire migration. Estimated time to migrate 10,000 members is 1 hour (optional, defaults to 12)'
         },
         {
             type: 'boolean',

--- a/packages/mg-stripe/src/lib/Options.ts
+++ b/packages/mg-stripe/src/lib/Options.ts
@@ -24,27 +24,27 @@ export class Options {
         {
             type: 'number',
             flags: '--delay',
-            defaultValue: 12,
-            desc: 'Period (in hours, starting now) during which payment collection is paused. This period should be large enough to perform the entire migration. Estimated time to migrate 10,000 members is 1 hour (optional, defaults to 12)'
+            defaultValue: false,
+            desc: 'Period (in hours, starting now) during which payment collection is paused. This period should be large enough to cover the entire migration. Estimated time to migrate 10,000 members is 1 hour, we recommend adding an extra hour of buffer time to be safe (optional)'
         },
         {
             type: 'boolean',
             flags: '--debug',
             defaultValue: false,
-            desc: 'Print debug output'
+            desc: 'Print debug output (optional)'
         },
         {
             type: 'number',
             flags: '--verbose -v',
             defaultValue: false,
-            desc: 'Print verbose output'
+            desc: 'Print verbose output (optional)'
         },
         {
             type: 'boolean',
             // Somehow -vv is not working in sywac
             flags: '--very-verbose',
             defaultValue: false,
-            desc: 'Print very verbose output'
+            desc: 'Print very verbose output (optional)'
         }
     ];
 
@@ -67,7 +67,7 @@ export class Options {
         this.debug = argv.debug ?? false;
         this.testClock = argv['test-clock'] ?? undefined;
         this.forceRecreate = argv['force-recreate'] ?? false;
-        this.delay = argv.delay ?? 12;
+        this.delay = argv.delay ?? undefined;
     }
 
     static init(argv: any) {

--- a/packages/mg-stripe/src/lib/Options.ts
+++ b/packages/mg-stripe/src/lib/Options.ts
@@ -55,7 +55,7 @@ export class Options {
     debug: boolean;
     testClock?: string;
     forceRecreate: boolean;
-    pausePeriod: number;
+    delay: number;
 
     static shared: Options;
 
@@ -67,7 +67,7 @@ export class Options {
         this.debug = argv.debug ?? false;
         this.testClock = argv['test-clock'] ?? undefined;
         this.forceRecreate = argv['force-recreate'] ?? false;
-        this.pausePeriod = argv.delay ?? 12;
+        this.delay = argv.delay ?? 12;
     }
 
     static init(argv: any) {

--- a/packages/mg-stripe/src/lib/StripeConnector.ts
+++ b/packages/mg-stripe/src/lib/StripeConnector.ts
@@ -16,16 +16,16 @@ export class StripeConnector {
             return stripe;
         }
 
-        // Show a selectino list
+        // Show a selection list
         const account = await select<'enter' | 'open'>({
             message,
             choices: [
                 {
-                    name: 'Enter API key manually',
+                    name: 'Enter Stripe API secret key',
                     value: 'enter'
                 },
                 {
-                    name: 'Open Stripe dashboard to create new API key',
+                    name: 'Open Stripe dashboard to get a Stripe API secret key',
                     value: 'open'
                 }
             ]
@@ -36,7 +36,7 @@ export class StripeConnector {
         if (account === 'enter') {
             // Prompts
             apiKey = await input({
-                message: 'Enter your Stripe API key'
+                message: 'Enter your Stripe API secret key:'
             });
         } else {
             const url = 'https://dashboard.stripe.com/apikeys';

--- a/packages/mg-stripe/src/lib/command.ts
+++ b/packages/mg-stripe/src/lib/command.ts
@@ -16,7 +16,7 @@ class StripeCSVCommand {
     id = 'stripe';
     group = 'Sources:';
     flags = 'stripe';
-    desc = 'Migrate your Stripe subscriptions to a different Stripe account';
+    desc = 'Migrate Stripe products, prices, coupons, invoices and subscriptions to another Stripe account';
 
     constructor() {
         // FIX `this` binding (sywac)
@@ -31,7 +31,7 @@ class StripeCSVCommand {
         sywac.command({
             id: 'copy',
             flags: 'copy',
-            desc: 'Copy subscriptions from one Stripe account to another. Pausing subscriptions in the old account and the newly created subscriptions. Before running this, make sure no new subscriptions can be created in the old Stripe account. This command can be run multiple times (already migrated subscriptions will be skipped).',
+            desc: 'Copy subscriptions from the old Stripe account to the new one. Before running this, make sure that the old site is not accepting any new subscriptions, and that you have migrated Stripe customers using the Stripe dashboard (https://stripe.com/docs/payments/account/data-migrations/pan-copy-self-serve). This command will pause existing subscriptions in the old account and activate them on the new account. The payment collection is paused in the new account by 12 hours by default (can be changed with the --delay option). This command can be run multiple times, already migrated subscriptions will be skipped.',
             run: async (argv: any) => {
                 const options = Options.init(argv);
                 Logger.init({verboseLevel: options.verboseLevel, debug: options.debug});
@@ -43,7 +43,7 @@ class StripeCSVCommand {
         sywac.command({
             id: 'confirm',
             flags: 'confirm',
-            desc: 'Confirm copy by unpausing the subscriptions created in the new Stripe account. If some old subscriptions were cancelled during the copy, it will also cancel them in the newly created subscription.',
+            desc: 'Confirm migration to the new Stripe account. This command will finalise any open invoices.',
             run: async (argv: any) => {
                 const options = Options.init(argv);
                 Logger.init({verboseLevel: options.verboseLevel, debug: options.debug});
@@ -55,7 +55,7 @@ class StripeCSVCommand {
         sywac.command({
             id: 'revert',
             flags: 'revert',
-            desc: 'Unpause the subscriptions created in the old Stripe account and revert all changes made to the new Stripe account.',
+            desc: 'Revert the migration. This command will clean up the new Stripe account and resume the subscriptions from the old Stripe account',
             run: async (argv: any) => {
                 const options = Options.init(argv);
                 Logger.init({verboseLevel: options.verboseLevel, debug: options.debug});

--- a/packages/mg-stripe/src/lib/commands/confirm.ts
+++ b/packages/mg-stripe/src/lib/commands/confirm.ts
@@ -74,9 +74,12 @@ export async function confirm(options: Options) {
         const subscriptionImporter = createSubscriptionImporter({
             ...sharedOptions,
             priceImporter,
-            couponImporter
+            couponImporter,
+            delay: 0
         });
+
         const warnings = await subscriptionImporter.confirmAll();
+
         if (warnings) {
             Logger.shared.succeed(`Successfully confirmed ${stats.importedPerType.get('subscription') ?? 0} subscriptions with ${warnings.length} warning${warnings.length > 1 ? 's' : ''}:`);
             Logger.shared.warn(warnings.toString());

--- a/packages/mg-stripe/src/lib/commands/confirm.ts
+++ b/packages/mg-stripe/src/lib/commands/confirm.ts
@@ -19,13 +19,13 @@ export async function confirm(options: Options) {
 
         Logger.shared.startSpinner('Validating API-key');
         const {accountName, mode} = await fromAccount.validate();
-        Logger.shared.succeed(`From: ${chalk.cyan(accountName)} in ${mode} mode`);
+        Logger.shared.succeed(`From ${chalk.cyan(accountName)} (${mode} account)`);
 
         const toAccount = await connector.askForAccount('Which Stripe account did you migrate to?', options.newApiKey);
 
         Logger.shared.startSpinner('Validating API-key');
         const {accountName: accountNameTo, mode: modeTo} = await toAccount.validate();
-        Logger.shared.succeed(`To: ${chalk.cyan(accountNameTo)} in ${modeTo} mode\n`);
+        Logger.shared.succeed(`To ${chalk.cyan(accountNameTo)} (${modeTo} account)\n`);
 
         if (toAccount.id === fromAccount.id) {
             Logger.shared.fail('You cannot migrate to the same account');

--- a/packages/mg-stripe/src/lib/commands/copy.ts
+++ b/packages/mg-stripe/src/lib/commands/copy.ts
@@ -8,7 +8,7 @@ import {createProductImporter} from '../importers/createProductImporter.js';
 import {createSubscriptionImporter} from '../importers/createSubscriptionImporter.js';
 import {Options} from '../Options.js';
 import {confirm} from '@inquirer/prompts';
-import input from '@inquirer/input';
+import {DelayPrompt} from '../DelayPrompt.js';
 
 export async function copy(options: Options) {
     const stats = new ImportStats();
@@ -33,25 +33,10 @@ export async function copy(options: Options) {
 
     try {
         // Get delay
-        let delay = options.delay;
+        const delay = await new DelayPrompt().ask(options.delay);
 
-        if (!options.dryRun) {
-            Logger.shared.info(`We recommend ${chalk.cyan('delaying payment collection')} from Stripe until the copy is finished, to avoid duplicate charges.`);
-            Logger.shared.info(`By default, we delay the payment collection for ${chalk.cyan(delay)} hours. As a rule of thumb, copying 10,000 subscriptions takes an hour. We suggest adding an extra hour of buffer time to be safe.`);
-
-            const delayInput = await input({
-                message: 'For how many hours would you like to pause payment collection?'
-            });
-            delay = parseInt(delayInput, 10);
-
-            if (!Number.isInteger(delay) || delay < 0) {
-                Logger.shared.fail('Expected a positive number of hours, to delay payment collection.');
-                process.exit(1);
-            }
-
-            Logger.shared.startSpinner('');
-            Logger.shared.succeed(`No payments will be collected for the next ${chalk.green(delay)} hour(s)`);
-        }
+        Logger.shared.startSpinner('');
+        Logger.shared.succeed(`No payments will be collected for the next ${chalk.green(delay)} hour(s)`);
 
         // Get from / to Stripe accounts
         const connector = new StripeConnector();

--- a/packages/mg-stripe/src/lib/commands/copy.ts
+++ b/packages/mg-stripe/src/lib/commands/copy.ts
@@ -12,17 +12,24 @@ import {confirm} from '@inquirer/prompts';
 export async function copy(options: Options) {
     const stats = new ImportStats();
 
-    Logger.shared.info('The "copy" command will migrate Stripe products, prices, coupons, invoices and subscriptions from an old to a new Stripe account.');
+    Logger.shared.info(`The ${chalk.cyan('copy')} command will migrate Stripe products, prices, coupons, invoices and subscriptions from an old to a new Stripe account.`);
     Logger.shared.info('------------------------------------------------------------------------------');
     Logger.shared.info('Before proceeding, be sure to have:');
     Logger.shared.info('1) Disabled new subscriptions on the old site');
     Logger.shared.info('2) Migrated Stripe customers, using the Stripe dashboard:');
     Logger.shared.info('https://stripe.com/docs/payments/account/data-migrations/pan-copy-self-serve');
     Logger.shared.info('------------------------------------------------------------------------------');
-    Logger.shared.info('We recommend running a dry run first, by passing the `--dry-run` option.');
+    Logger.shared.info(`We recommend running a dry run first, by passing the ${chalk.cyan('--dry-run')} option.`);
     Logger.shared.info('The dry run will not create any data object in the new account, nor update anything in the old account.');
     Logger.shared.info('------------------------------------------------------------------------------');
-    Logger.shared.info('When you are ready to perform the copy, be sure to check the `--delay` option. This option will pause payment collection by a number of hours, so that no payments are made during the migration (defaults to 12).');
+    Logger.shared.info(`When you are ready to perform the copy, be sure to check the ${chalk.cyan('--delay')} option. This option will pause payment collection by a number of hours, so that no payments are made during the migration (defaults to 12).`);
+    Logger.shared.info('------------------------------------------------------------------------------');
+
+    if (options.dryRun) {
+        Logger.shared.succeed(`${chalk.green('Running copy in DRY RUN mode. No Stripe data will be created or updated.')}`);
+    } else {
+        Logger.shared.succeed(`${chalk.green(`Running copy in LIVE mode. Payment collection will be paused for ${options.delay} hours (see --delay option).`)}`);
+    }
 
     try {
         // Step 1: Connect to Stripe

--- a/packages/mg-stripe/src/lib/commands/copy.ts
+++ b/packages/mg-stripe/src/lib/commands/copy.ts
@@ -12,6 +12,18 @@ import {confirm} from '@inquirer/prompts';
 export async function copy(options: Options) {
     const stats = new ImportStats();
 
+    Logger.shared.info('The "copy" command will migrate Stripe products, prices, coupons, invoices and subscriptions from an old to a new Stripe account.');
+    Logger.shared.info('------------------------------------------------------------------------------');
+    Logger.shared.info('Before proceeding, be sure to have:');
+    Logger.shared.info('1) Disabled new subscriptions on the old site');
+    Logger.shared.info('2) Migrated Stripe customers, using the Stripe dashboard:');
+    Logger.shared.info('https://stripe.com/docs/payments/account/data-migrations/pan-copy-self-serve');
+    Logger.shared.info('------------------------------------------------------------------------------');
+    Logger.shared.info('We recommend running a dry run first, by passing the `--dry-run` option.');
+    Logger.shared.info('The dry run will not create any data object in the new account, nor update anything in the old account.');
+    Logger.shared.info('------------------------------------------------------------------------------');
+    Logger.shared.info('When you are ready to perform the copy, be sure to check the `--delay` option. This option will pause payment collection by a number of hours, so that no payments are made during the migration (defaults to 12).');
+
     try {
         // Step 1: Connect to Stripe
         const connector = new StripeConnector();

--- a/packages/mg-stripe/src/lib/commands/revert.ts
+++ b/packages/mg-stripe/src/lib/commands/revert.ts
@@ -19,13 +19,13 @@ export async function revert(options: Options) {
 
         Logger.shared.startSpinner('Validating API-key');
         const {accountName, mode} = await fromAccount.validate();
-        Logger.shared.succeed(`From: ${chalk.cyan(accountName)} in ${mode} mode`);
+        Logger.shared.succeed(`From ${chalk.cyan(accountName)} (${mode} account)`);
 
         const toAccount = await connector.askForAccount('Which Stripe account did you migrate to?', options.newApiKey);
 
         Logger.shared.startSpinner('Validating API-key');
         const {accountName: accountNameTo, mode: modeTo} = await toAccount.validate();
-        Logger.shared.succeed(`To: ${chalk.cyan(accountNameTo)} in ${modeTo} mode\n`);
+        Logger.shared.succeed(`To ${chalk.cyan(accountNameTo)} (${modeTo} account)\n`);
 
         if (toAccount.id === fromAccount.id) {
             Logger.shared.fail('You cannot migrate to the same account');

--- a/packages/mg-stripe/src/lib/commands/revert.ts
+++ b/packages/mg-stripe/src/lib/commands/revert.ts
@@ -12,6 +12,20 @@ import {confirm as _confirm} from '@inquirer/prompts';
 export async function revert(options: Options) {
     const stats = new ImportStats();
 
+    Logger.shared.info(`The ${chalk.cyan('revert')} command will delete the copy of Stripe products, prices, coupons, subscriptions and invoices from the new Stripe account. It will also resume the subscriptions in the old Stripe account.`);
+    Logger.shared.info('------------------------------------------------------------------------------');
+    Logger.shared.info('Before proceeding, be sure to have:');
+    Logger.shared.info(`1) Executed the ${chalk.cyan('copy')} command`);
+    Logger.shared.info('2) Verified that the errors cannot be resolved manually from the Stripe dashboard');
+    Logger.shared.info('------------------------------------------------------------------------------');
+
+    Logger.shared.startSpinner('');
+    if (options.dryRun) {
+        Logger.shared.succeed(`Starting revert in ${chalk.green('DRY RUN')} mode.`);
+    } else {
+        Logger.shared.succeed(`Starting revert in ${chalk.green('LIVE')} mode.`);
+    }
+
     try {
         // Step 1: Connect to Stripe
         const connector = new StripeConnector();
@@ -28,7 +42,7 @@ export async function revert(options: Options) {
         Logger.shared.succeed(`To ${chalk.cyan(accountNameTo)} (${modeTo} account)\n`);
 
         if (toAccount.id === fromAccount.id) {
-            Logger.shared.fail('You cannot have copied to the same account');
+            Logger.shared.fail('You cannot revert a copy from the same account');
             process.exit(1);
         }
 

--- a/packages/mg-stripe/src/lib/importers/createSubscriptionImporter.ts
+++ b/packages/mg-stripe/src/lib/importers/createSubscriptionImporter.ts
@@ -31,13 +31,14 @@ async function finalizeDraftInvoices(stripe: StripeAPI, subscription: Stripe.Sub
     }
 }
 
-export function createSubscriptionImporter({oldStripe, newStripe, stats, priceImporter, couponImporter}: {
+export function createSubscriptionImporter({oldStripe, newStripe, stats, priceImporter, couponImporter, delay}: {
     dryRun: boolean,
     oldStripe: StripeAPI,
     newStripe: StripeAPI,
     stats: ImportStats,
     priceImporter: Importer<Stripe.Price>,
-    couponImporter: Importer<Stripe.Coupon>
+    couponImporter: Importer<Stripe.Coupon>,
+    delay: number,
 }) {
     const provider = {
         async getByID(oldId: string): Promise<Stripe.Subscription> {
@@ -178,7 +179,7 @@ export function createSubscriptionImporter({oldStripe, newStripe, stats, priceIm
             const now = new Date().getTime() / 1000;
 
             // Minimum billing_cycle_anchor is one hour in the future, to prevent immediate billing of the created subscription
-            const minimumFirstCharge = 3600 * Math.max(0.5, Options.shared.delay); // Wait x hours
+            const minimumFirstCharge = 3600 * Math.max(0.5, delay); // Wait x hours
             const minimumBillingCycleAnchor = Math.ceil(now) + minimumFirstCharge;
             const isTrial = oldSubscription.trial_end && oldSubscription.trial_end > (now + 10);
 

--- a/packages/mg-stripe/src/lib/importers/createSubscriptionImporter.ts
+++ b/packages/mg-stripe/src/lib/importers/createSubscriptionImporter.ts
@@ -178,7 +178,7 @@ export function createSubscriptionImporter({oldStripe, newStripe, stats, priceIm
             const now = new Date().getTime() / 1000;
 
             // Minimum billing_cycle_anchor is one hour in the future, to prevent immediate billing of the created subscription
-            const minimumFirstCharge = 3600 * Math.max(0.5, Options.shared.pausePeriod); // Wait x hours
+            const minimumFirstCharge = 3600 * Math.max(0.5, Options.shared.delay); // Wait x hours
             const minimumBillingCycleAnchor = Math.ceil(now) + minimumFirstCharge;
             const isTrial = oldSubscription.trial_end && oldSubscription.trial_end > (now + 10);
 

--- a/packages/mg-stripe/src/test/subscriptions.test.ts
+++ b/packages/mg-stripe/src/test/subscriptions.test.ts
@@ -45,6 +45,8 @@ describe('Recreating subscriptions', () => {
             delay: 1
         });
 
+        const delay = Options.shared.delay;
+
         const productImporter = createProductImporter({
             ...sharedOptions
         });
@@ -61,7 +63,8 @@ describe('Recreating subscriptions', () => {
         subscriptionImporter = createSubscriptionImporter({
             ...sharedOptions,
             priceImporter,
-            couponImporter
+            couponImporter,
+            delay
         });
 
         sinon.stub(sharedOptions.oldStripe.client.invoices, 'list').callsFake(() => {


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3626

- added the key information and check points before executing the copy, confirm and revert commands
- moved the `delay` option to an explicit prompt, to explain why it's necessary and the recommended duration. The option can still be passed as `--delay` directly in the command