### PR TITLE
Add functionality to only copy Stripe subscriptions from a CSV

### DIFF
--- a/packages/mg-stripe/README.md
+++ b/packages/mg-stripe/README.md
@@ -46,6 +46,17 @@ Some other useful options are:
 - `--to`: the Stripe API secret key of the new account (optional)
 - `--delay`: Period (in hours, starting now) during which payment collection is paused. This period should be large enough to cover the entire migration. Estimated time to migrate 10,000 members is 1 hour, we recommend adding an extra hour of buffer time to be safe (optional)
 - `--subscription`: Only migrate a specific subscription id (optional). The value should be the subscription ID, i.e. `sub_1234abcd5678efgh1234abcd`
+- `--subscriptions-csv`: Path to a CSV file containing subscription IDs to migrate (optional). The CSV must have a `subscription_id` column header. Cannot be used with `--subscription`
+
+Here's an example of the CSV that should be passed to `subscriptions-csv`.
+
+```csv
+subscription_id,customer_email
+sub_1234abcd5678efgh,user1@example.com
+sub_2345bcde6789fghi,user2@example.com
+sub_3456cdef7890ghij,user3@example.com
+sub_4567defg8901hijk,user4@example.com
+```
 
 See full list of options [here](https://github.com/TryGhost/migrate/blob/main/packages/mg-stripe/src/lib/Options.ts).
 

--- a/packages/mg-stripe/src/lib/Options.ts
+++ b/packages/mg-stripe/src/lib/Options.ts
@@ -28,6 +28,12 @@ export class Options {
             desc: 'Only migrate a specific subscription id (optional)'
         },
         {
+            type: 'string',
+            flags: '--subscriptions-csv',
+            defaultValue: false,
+            desc: 'Path to CSV file containing subscription IDs to migrate (optional)'
+        },
+        {
             type: 'number',
             flags: '--delay',
             defaultValue: null,
@@ -63,6 +69,7 @@ export class Options {
     forceRecreate: boolean;
     delay: number | null;
     subscription: string | null;
+    subscriptionsCsv: string | null;
 
     static shared: Options;
 
@@ -76,6 +83,7 @@ export class Options {
         this.forceRecreate = argv['force-recreate'] ?? false;
         this.delay = argv.delay ?? null;
         this.subscription = argv.subscription ?? null;
+        this.subscriptionsCsv = argv['subscriptions-csv'] ?? null;
     }
 
     static init(argv: any) {

--- a/packages/mg-stripe/src/lib/csvReader.ts
+++ b/packages/mg-stripe/src/lib/csvReader.ts
@@ -1,0 +1,58 @@
+import {readFileSync} from 'fs';
+import {Logger} from './Logger.js';
+
+export function readSubscriptionIdsFromCsv(filePath: string): string[] {
+    try {
+        const fileContent = readFileSync(filePath, 'utf-8');
+        const lines = fileContent.split('\n').filter(line => line.trim());
+        
+        if (lines.length === 0) {
+            throw new Error('CSV file is empty');
+        }
+        
+        // Parse CSV header
+        const header = lines[0].trim().toLowerCase();
+        const columns = header.split(',').map(col => col.trim());
+        
+        // Find the subscription_id column index
+        const subscriptionIdIndex = columns.indexOf('subscription_id');
+        
+        if (subscriptionIdIndex === -1) {
+            throw new Error('CSV file must have a "subscription_id" column');
+        }
+        
+        const subscriptionIds: string[] = [];
+        
+        // Process data rows (skip header)
+        for (let i = 1; i < lines.length; i++) {
+            const line = lines[i].trim();
+            
+            // Skip empty lines
+            if (!line) {
+                continue;
+            }
+            
+            // Split by comma and get the subscription_id column value
+            const values = line.split(',').map(val => val.trim());
+            
+            if (values.length > subscriptionIdIndex) {
+                const id = values[subscriptionIdIndex];
+                
+                // Basic validation for subscription ID format (starts with sub_)
+                if (id && id.startsWith('sub_')) {
+                    subscriptionIds.push(id);
+                } else if (id) {
+                    Logger.shared.warn(`Line ${i + 1}: Skipping invalid subscription ID: ${id}`);
+                }
+            }
+        }
+        
+        if (subscriptionIds.length === 0) {
+            throw new Error('No valid subscription IDs found in CSV file');
+        }
+        
+        return subscriptionIds;
+    } catch (error: any) {
+        throw new Error(`Failed to read CSV file: ${error.message}`);
+    }
+}


### PR DESCRIPTION
This complements the existing `--subscription sub_1234` behaviour by allowing multiple IDs to be copied.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces CSV-driven selective subscription migration for the `copy` command.
> 
> - Adds `--subscriptions-csv` option in `Options.ts`; parses file via new `csvReader.ts` to collect `subscription_id`s with basic validation and warnings
> - Enforces mutual exclusivity between `--subscription` and `--subscriptions-csv`; logs and exits on conflict
> - Updates `copy.ts` to iterate `recreateByID` over provided IDs; otherwise falls back to `recreateAll`
> - Updates `README.md` with flag description and CSV example
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec52914c77e09a69998983e5c6e457a41255a95b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->