### PR TITLE
Add automatic embed shortcode support for WP tools

### DIFF
--- a/packages/mg-wp-api/lib/embed-utils.js
+++ b/packages/mg-wp-api/lib/embed-utils.js
@@ -1,0 +1,173 @@
+const EMBED_SERVICES = [
+    {
+        name: 'youtube',
+        patterns: [
+            /(?:https?:\/\/)?(?:www\.)?youtube\.com\/watch\?.*v=([\w-]+)/i,
+            /(?:https?:\/\/)?(?:www\.)?youtube\.com\/embed\/([\w-]+)/i,
+            /(?:https?:\/\/)?(?:www\.)?youtube\.com\/shorts\/([\w-]+)/i,
+            /(?:https?:\/\/)?(?:www\.)?youtube\.com\/live\/([\w-]+)/i,
+            /(?:https?:\/\/)?youtu\.be\/([\w-]+)/i,
+            /(?:https?:\/\/)?(?:www\.)?youtube-nocookie\.com\/embed\/([\w-]+)/i
+        ],
+        buildEmbedHtml(id) {
+            return `<figure class="kg-card kg-embed-card"><iframe src="https://www.youtube.com/embed/${id}?feature=oembed" width="160" height="90" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></figure>`;
+        },
+        extractId(url) {
+            for (const pattern of this.patterns) {
+                const match = url.match(pattern);
+                if (match && match[1]) {
+                    return match[1];
+                }
+            }
+            return null;
+        }
+    },
+    {
+        name: 'vimeo',
+        patterns: [
+            /(?:https?:\/\/)?(?:www\.)?vimeo\.com\/(\d+)/i,
+            /(?:https?:\/\/)?player\.vimeo\.com\/video\/(\d+)/i
+        ],
+        buildEmbedHtml(id) {
+            return `<figure class="kg-card kg-embed-card"><iframe src="https://player.vimeo.com/video/${id}" width="160" height="90" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe></figure>`;
+        }
+    },
+    {
+        name: 'spotify',
+        patterns: [
+            /(?:https?:\/\/)?open\.spotify\.com\/(track|album|playlist|episode|show)\/([\w]+)/i,
+            /(?:https?:\/\/)?open\.spotify\.com\/embed\/(track|album|playlist|episode|show)\/([\w]+)/i
+        ],
+        buildEmbedHtml(id, groups) {
+            const type = groups[0];
+            const trackId = groups[1];
+            return `<figure class="kg-card kg-embed-card"><iframe src="https://open.spotify.com/embed/${type}/${trackId}" width="100%" height="352" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></figure>`;
+        },
+        extractId(url) {
+            for (const pattern of this.patterns) {
+                const match = url.match(pattern);
+                if (match) {
+                    return {id: match[2], groups: [match[1], match[2]]};
+                }
+            }
+            return null;
+        }
+    },
+    {
+        name: 'dailymotion',
+        patterns: [
+            /(?:https?:\/\/)?(?:www\.)?dailymotion\.com\/video\/([\w]+)/i,
+            /(?:https?:\/\/)?(?:www\.)?dailymotion\.com\/embed\/video\/([\w]+)/i,
+            /(?:https?:\/\/)?dai\.ly\/([\w]+)/i
+        ],
+        buildEmbedHtml(id) {
+            return `<figure class="kg-card kg-embed-card"><iframe src="https://www.dailymotion.com/embed/video/${id}" width="160" height="90" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe></figure>`;
+        }
+    },
+    {
+        name: 'soundcloud',
+        patterns: [
+            /(?:https?:\/\/)?(?:www\.)?soundcloud\.com\/([\w-]+)\/([\w-]+)/i,
+            /(?:https?:\/\/)?w\.soundcloud\.com\/player\/\?url=/i
+        ],
+        buildEmbedHtml(_id, _groups, originalUrl) {
+            return `<figure class="kg-card kg-embed-card"><iframe src="${originalUrl}" width="100%" height="166" frameborder="0" allow="autoplay"></iframe></figure>`;
+        },
+        extractId(url) {
+            for (const pattern of this.patterns) {
+                const match = url.match(pattern);
+                if (match) {
+                    return {id: match[1] || 'soundcloud', groups: match.slice(1)};
+                }
+            }
+            return null;
+        }
+    },
+    {
+        name: 'twitter',
+        patterns: [
+            /(?:https?:\/\/)?(?:www\.)?twitter\.com\/\w+\/status\/(\d+)/i,
+            /(?:https?:\/\/)?(?:www\.)?x\.com\/\w+\/status\/(\d+)/i
+        ],
+        buildEmbedHtml(_id, _groups, originalUrl) {
+            return `<!--kg-card-begin: embed--><figure class="kg-card kg-embed-card"><blockquote class="twitter-tweet"><a href="${originalUrl}"></a></blockquote><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script></figure><!--kg-card-end: embed-->`;
+        }
+    },
+    {
+        name: 'instagram',
+        patterns: [
+            /(?:https?:\/\/)?(?:www\.)?instagram\.com\/p\/([\w-]+)/i,
+            /(?:https?:\/\/)?(?:www\.)?instagram\.com\/reel\/([\w-]+)/i
+        ],
+        buildEmbedHtml(_id, _groups, originalUrl) {
+            return `<figure class="kg-card kg-embed-card"><blockquote class="instagram-media" data-instgrm-permalink="${originalUrl}"><a href="${originalUrl}"></a></blockquote><script async src="//www.instagram.com/embed.js"></script></figure>`;
+        }
+    },
+    {
+        name: 'bluesky',
+        patterns: [
+            /(?:https?:\/\/)?bsky\.app\/profile\/[\w.:-]+\/post\/([\w]+)/i
+        ],
+        buildEmbedHtml(_id, _groups, originalUrl) {
+            return `<figure class="kg-card kg-embed-card"><blockquote><a href="${originalUrl}"></a></blockquote></figure>`;
+        }
+    },
+    {
+        name: 'tiktok',
+        patterns: [
+            /(?:https?:\/\/)?(?:www\.)?tiktok\.com\/@[\w.-]+\/video\/(\d+)/i
+        ],
+        buildEmbedHtml(_id, _groups, originalUrl) {
+            return `<figure class="kg-card kg-embed-card"><blockquote><a href="${originalUrl}"></a></blockquote></figure>`;
+        }
+    }
+];
+
+/**
+ * Test a URL string against all known embed service patterns.
+ * Returns {service, id, groups, url} on match, or null.
+ */
+const matchEmbedUrl = (url) => {
+    if (!url || typeof url !== 'string') {
+        return null;
+    }
+
+    const trimmed = url.trim();
+    if (!trimmed) {
+        return null;
+    }
+
+    for (const service of EMBED_SERVICES) {
+        if (service.extractId) {
+            const result = service.extractId(trimmed);
+            if (result) {
+                const id = typeof result === 'string' ? result : result.id;
+                const groups = typeof result === 'string' ? [result] : result.groups;
+                if (id) {
+                    return {service: service.name, id, groups, url: trimmed, buildEmbedHtml: service.buildEmbedHtml.bind(service)};
+                }
+            }
+        } else {
+            for (const pattern of service.patterns) {
+                const match = trimmed.match(pattern);
+                if (match && match[1]) {
+                    return {service: service.name, id: match[1], groups: match.slice(1), url: trimmed, buildEmbedHtml: service.buildEmbedHtml.bind(service)};
+                }
+            }
+        }
+    }
+
+    return null;
+};
+
+/**
+ * Given a match result from matchEmbedUrl, produce the Ghost embed HTML.
+ */
+const buildEmbedHtml = (match) => {
+    if (!match) {
+        return null;
+    }
+    return match.buildEmbedHtml(match.id, match.groups, match.url);
+};
+
+export {EMBED_SERVICES, matchEmbedUrl, buildEmbedHtml};

--- a/packages/mg-wp-api/lib/embed-utils.js
+++ b/packages/mg-wp-api/lib/embed-utils.js
@@ -1,3 +1,23 @@
+const escapeHtmlAttr = (str) => {
+    return str
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+};
+
+const sanitizeUrl = (url) => {
+    try {
+        const parsed = new URL(url);
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+            return null;
+        }
+        return escapeHtmlAttr(parsed.href);
+    } catch {
+        return null;
+    }
+};
+
 const EMBED_SERVICES = [
     {
         name: 'youtube',
@@ -71,7 +91,11 @@ const EMBED_SERVICES = [
             /(?:https?:\/\/)?w\.soundcloud\.com\/player\/\?url=/i
         ],
         buildEmbedHtml(_id, _groups, originalUrl) {
-            return `<figure class="kg-card kg-embed-card"><iframe src="${originalUrl}" width="100%" height="166" frameborder="0" allow="autoplay"></iframe></figure>`;
+            const safe = sanitizeUrl(originalUrl);
+            if (!safe) {
+                return '';
+            }
+            return `<figure class="kg-card kg-embed-card"><iframe src="${safe}" width="100%" height="166" frameborder="0" allow="autoplay"></iframe></figure>`;
         },
         extractId(url) {
             for (const pattern of this.patterns) {
@@ -90,7 +114,11 @@ const EMBED_SERVICES = [
             /(?:https?:\/\/)?(?:www\.)?x\.com\/\w+\/status\/(\d+)/i
         ],
         buildEmbedHtml(_id, _groups, originalUrl) {
-            return `<!--kg-card-begin: embed--><figure class="kg-card kg-embed-card"><blockquote class="twitter-tweet"><a href="${originalUrl}"></a></blockquote><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script></figure><!--kg-card-end: embed-->`;
+            const safe = sanitizeUrl(originalUrl);
+            if (!safe) {
+                return '';
+            }
+            return `<!--kg-card-begin: embed--><figure class="kg-card kg-embed-card"><blockquote class="twitter-tweet"><a href="${safe}"></a></blockquote><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script></figure><!--kg-card-end: embed-->`;
         }
     },
     {
@@ -100,7 +128,11 @@ const EMBED_SERVICES = [
             /(?:https?:\/\/)?(?:www\.)?instagram\.com\/reel\/([\w-]+)/i
         ],
         buildEmbedHtml(_id, _groups, originalUrl) {
-            return `<figure class="kg-card kg-embed-card"><blockquote class="instagram-media" data-instgrm-permalink="${originalUrl}"><a href="${originalUrl}"></a></blockquote><script async src="//www.instagram.com/embed.js"></script></figure>`;
+            const safe = sanitizeUrl(originalUrl);
+            if (!safe) {
+                return '';
+            }
+            return `<figure class="kg-card kg-embed-card"><blockquote class="instagram-media" data-instgrm-permalink="${safe}"><a href="${safe}"></a></blockquote><script async src="//www.instagram.com/embed.js"></script></figure>`;
         }
     },
     {
@@ -109,7 +141,11 @@ const EMBED_SERVICES = [
             /(?:https?:\/\/)?bsky\.app\/profile\/[\w.:-]+\/post\/([\w]+)/i
         ],
         buildEmbedHtml(_id, _groups, originalUrl) {
-            return `<figure class="kg-card kg-embed-card"><blockquote><a href="${originalUrl}"></a></blockquote></figure>`;
+            const safe = sanitizeUrl(originalUrl);
+            if (!safe) {
+                return '';
+            }
+            return `<figure class="kg-card kg-embed-card"><blockquote><a href="${safe}"></a></blockquote></figure>`;
         }
     },
     {
@@ -118,7 +154,11 @@ const EMBED_SERVICES = [
             /(?:https?:\/\/)?(?:www\.)?tiktok\.com\/@[\w.-]+\/video\/(\d+)/i
         ],
         buildEmbedHtml(_id, _groups, originalUrl) {
-            return `<figure class="kg-card kg-embed-card"><blockquote><a href="${originalUrl}"></a></blockquote></figure>`;
+            const safe = sanitizeUrl(originalUrl);
+            if (!safe) {
+                return '';
+            }
+            return `<figure class="kg-card kg-embed-card"><blockquote><a href="${safe}"></a></blockquote></figure>`;
         }
     }
 ];

--- a/packages/mg-wp-api/lib/processor.js
+++ b/packages/mg-wp-api/lib/processor.js
@@ -12,6 +12,7 @@ import galleryCard from '@tryghost/kg-default-cards/lib/cards/gallery.js';
 import imageCard from '@tryghost/kg-default-cards/lib/cards/image.js';
 import bookmarkCard from '@tryghost/kg-default-cards/lib/cards/bookmark.js';
 import {domUtils, youtubeUtils, stringUtils} from '@tryghost/mg-utils';
+import {matchEmbedUrl, buildEmbedHtml} from './embed-utils.js';
 
 const {unescapeHTML, stripHtml} = stringUtils;
 
@@ -461,11 +462,9 @@ const processShortcodes = async ({html, options}) => {
         if (!embedUrl) {
             return '';
         }
-        if (/youtu\.?be/.test(embedUrl)) {
-            const videoID = getYouTubeID(embedUrl);
-            if (videoID) {
-                return `<iframe loading="lazy" title="" width="160" height="90" src="https://www.youtube.com/embed/${videoID}?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe>`;
-            }
+        const match = matchEmbedUrl(embedUrl);
+        if (match) {
+            return buildEmbedHtml(match);
         }
         return content;
     });
@@ -484,7 +483,78 @@ const processShortcodes = async ({html, options}) => {
     shortcodes.unwrap('et_pb_column');
     shortcodes.unwrap('et_pb_row');
 
-    return shortcodes.parse(html);
+    let result = shortcodes.parse(html);
+
+    result = processUnknownEmbedShortcodes(result);
+
+    return result;
+};
+
+const SHORTCODE_REGEX = /\[([a-zA-Z_][\w-]*)(?<attrs>\s[\s\S]*?)?\](?:(?<content>[\s\S]*?)\[\/\1\])?/g;
+const SINGLE_URL_REGEX = /^https?:\/\/\S+$/;
+
+const processUnknownEmbedShortcodes = (html) => {
+    if (!html) {
+        return html;
+    }
+
+    return html.replace(SHORTCODE_REGEX, (fullMatch, _name, attrsString, content) => {
+        // Check content first — must be a single URL (no surrounding text)
+        if (content) {
+            const trimmed = content.trim();
+            if (SINGLE_URL_REGEX.test(trimmed)) {
+                const match = matchEmbedUrl(trimmed);
+                if (match) {
+                    return buildEmbedHtml(match);
+                }
+            }
+        }
+
+        // Check attribute values for recognisable embed URLs
+        if (attrsString) {
+            const attrValues = extractAttrValues(attrsString);
+            for (const value of attrValues) {
+                const match = matchEmbedUrl(value);
+                if (match) {
+                    return buildEmbedHtml(match);
+                }
+            }
+        }
+
+        return fullMatch;
+    });
+};
+
+const extractAttrValues = (attrsString) => {
+    const values = [];
+    // Match quoted values: key="value" or key='value'
+    const quotedRegex = /[\w-]+\s*=\s*"([^"]*?)"|[\w-]+\s*=\s*'([^']*?)'/g;
+    let match;
+
+    while ((match = quotedRegex.exec(attrsString)) !== null) {
+        const value = match[1] ?? match[2];
+        if (value) {
+            values.push(value);
+        }
+    }
+
+    // Match unquoted values: key=value (no spaces in value)
+    const unquotedRegex = /[\w-]+\s*=\s*([^\s"'][^\s]*)/g;
+    while ((match = unquotedRegex.exec(attrsString)) !== null) {
+        if (match[1]) {
+            values.push(match[1]);
+        }
+    }
+
+    // Match positional (bare) values that look like URLs
+    const positionalRegex = /(?:^|\s)(https?:\/\/\S+)/g;
+    while ((match = positionalRegex.exec(attrsString)) !== null) {
+        if (match[1]) {
+            values.push(match[1]);
+        }
+    }
+
+    return values;
 };
 
 /**
@@ -1379,6 +1449,7 @@ export default {
     processCoAuthors,
     processExcerpt,
     processShortcodes,
+    processUnknownEmbedShortcodes,
     processContent,
     processPost,
     processPosts,

--- a/packages/mg-wp-api/test/embed-utils.test.js
+++ b/packages/mg-wp-api/test/embed-utils.test.js
@@ -1,0 +1,319 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+import {matchEmbedUrl, buildEmbedHtml} from '../lib/embed-utils.js';
+
+describe('matchEmbedUrl', function () {
+    describe('YouTube', function () {
+        it('Matches youtube.com/watch URL', function () {
+            const result = matchEmbedUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+            assert.equal(result.service, 'youtube');
+            assert.equal(result.id, 'dQw4w9WgXcQ');
+        });
+
+        it('Matches youtu.be short URL', function () {
+            const result = matchEmbedUrl('https://youtu.be/dQw4w9WgXcQ');
+            assert.equal(result.service, 'youtube');
+            assert.equal(result.id, 'dQw4w9WgXcQ');
+        });
+
+        it('Matches youtube.com/embed URL', function () {
+            const result = matchEmbedUrl('https://www.youtube.com/embed/dQw4w9WgXcQ');
+            assert.equal(result.service, 'youtube');
+            assert.equal(result.id, 'dQw4w9WgXcQ');
+        });
+
+        it('Matches youtube.com/shorts URL', function () {
+            const result = matchEmbedUrl('https://www.youtube.com/shorts/dQw4w9WgXcQ');
+            assert.equal(result.service, 'youtube');
+            assert.equal(result.id, 'dQw4w9WgXcQ');
+        });
+
+        it('Matches youtube.com/live URL', function () {
+            const result = matchEmbedUrl('https://www.youtube.com/live/dQw4w9WgXcQ');
+            assert.equal(result.service, 'youtube');
+            assert.equal(result.id, 'dQw4w9WgXcQ');
+        });
+
+        it('Matches youtube-nocookie.com/embed URL', function () {
+            const result = matchEmbedUrl('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ');
+            assert.equal(result.service, 'youtube');
+            assert.equal(result.id, 'dQw4w9WgXcQ');
+        });
+
+        it('Matches URL with extra params', function () {
+            const result = matchEmbedUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=30s');
+            assert.equal(result.service, 'youtube');
+            assert.equal(result.id, 'dQw4w9WgXcQ');
+        });
+
+        it('Matches youtu.be with tracking param', function () {
+            const result = matchEmbedUrl('https://youtu.be/abcd1234?si=bcde2345');
+            assert.equal(result.service, 'youtube');
+            assert.equal(result.id, 'abcd1234');
+        });
+    });
+
+    describe('Vimeo', function () {
+        it('Matches vimeo.com/{id}', function () {
+            const result = matchEmbedUrl('https://vimeo.com/123456789');
+            assert.equal(result.service, 'vimeo');
+            assert.equal(result.id, '123456789');
+        });
+
+        it('Matches player.vimeo.com/video/{id}', function () {
+            const result = matchEmbedUrl('https://player.vimeo.com/video/123456789');
+            assert.equal(result.service, 'vimeo');
+            assert.equal(result.id, '123456789');
+        });
+
+        it('Matches without https', function () {
+            const result = matchEmbedUrl('http://vimeo.com/987654321');
+            assert.equal(result.service, 'vimeo');
+            assert.equal(result.id, '987654321');
+        });
+    });
+
+    describe('Spotify', function () {
+        it('Matches open.spotify.com/track/{id}', function () {
+            const result = matchEmbedUrl('https://open.spotify.com/track/4PTG3Z6ehGkBFwjybzWkR8');
+            assert.equal(result.service, 'spotify');
+            assert.equal(result.id, '4PTG3Z6ehGkBFwjybzWkR8');
+        });
+
+        it('Matches open.spotify.com/album/{id}', function () {
+            const result = matchEmbedUrl('https://open.spotify.com/album/1DFixLWuPkv3KT3TnV35m3');
+            assert.equal(result.service, 'spotify');
+            assert.equal(result.id, '1DFixLWuPkv3KT3TnV35m3');
+        });
+
+        it('Matches open.spotify.com/playlist/{id}', function () {
+            const result = matchEmbedUrl('https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M');
+            assert.equal(result.service, 'spotify');
+            assert.equal(result.id, '37i9dQZF1DXcBWIGoYBM5M');
+        });
+
+        it('Matches open.spotify.com/episode/{id}', function () {
+            const result = matchEmbedUrl('https://open.spotify.com/episode/abc123def456');
+            assert.equal(result.service, 'spotify');
+            assert.equal(result.id, 'abc123def456');
+        });
+
+        it('Matches open.spotify.com/show/{id}', function () {
+            const result = matchEmbedUrl('https://open.spotify.com/show/abc123def456');
+            assert.equal(result.service, 'spotify');
+            assert.equal(result.id, 'abc123def456');
+        });
+
+        it('Matches embed URL', function () {
+            const result = matchEmbedUrl('https://open.spotify.com/embed/track/4PTG3Z6ehGkBFwjybzWkR8');
+            assert.equal(result.service, 'spotify');
+            assert.equal(result.id, '4PTG3Z6ehGkBFwjybzWkR8');
+        });
+    });
+
+    describe('Dailymotion', function () {
+        it('Matches dailymotion.com/video/{id}', function () {
+            const result = matchEmbedUrl('https://www.dailymotion.com/video/x7tgad');
+            assert.equal(result.service, 'dailymotion');
+            assert.equal(result.id, 'x7tgad');
+        });
+
+        it('Matches dailymotion.com/embed/video/{id}', function () {
+            const result = matchEmbedUrl('https://www.dailymotion.com/embed/video/x7tgad');
+            assert.equal(result.service, 'dailymotion');
+            assert.equal(result.id, 'x7tgad');
+        });
+
+        it('Matches dai.ly/{id}', function () {
+            const result = matchEmbedUrl('https://dai.ly/x7tgad');
+            assert.equal(result.service, 'dailymotion');
+            assert.equal(result.id, 'x7tgad');
+        });
+    });
+
+    describe('SoundCloud', function () {
+        it('Matches soundcloud.com/{user}/{track}', function () {
+            const result = matchEmbedUrl('https://soundcloud.com/artist-name/track-name');
+            assert.equal(result.service, 'soundcloud');
+        });
+
+        it('Matches w.soundcloud.com/player URL', function () {
+            const result = matchEmbedUrl('https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/123');
+            assert.equal(result.service, 'soundcloud');
+        });
+    });
+
+    describe('Twitter/X', function () {
+        it('Matches twitter.com status URL', function () {
+            const result = matchEmbedUrl('https://twitter.com/user/status/1234567890');
+            assert.equal(result.service, 'twitter');
+            assert.equal(result.id, '1234567890');
+        });
+
+        it('Matches x.com status URL', function () {
+            const result = matchEmbedUrl('https://x.com/user/status/1234567890');
+            assert.equal(result.service, 'twitter');
+            assert.equal(result.id, '1234567890');
+        });
+
+        it('Matches without www', function () {
+            const result = matchEmbedUrl('https://twitter.com/someuser/status/9876543210');
+            assert.equal(result.service, 'twitter');
+            assert.equal(result.id, '9876543210');
+        });
+    });
+
+    describe('Instagram', function () {
+        it('Matches instagram.com/p/{id}', function () {
+            const result = matchEmbedUrl('https://www.instagram.com/p/CxYz123AbC/');
+            assert.equal(result.service, 'instagram');
+            assert.equal(result.id, 'CxYz123AbC');
+        });
+
+        it('Matches instagram.com/reel/{id}', function () {
+            const result = matchEmbedUrl('https://www.instagram.com/reel/CxYz123AbC/');
+            assert.equal(result.service, 'instagram');
+            assert.equal(result.id, 'CxYz123AbC');
+        });
+    });
+
+    describe('Bluesky', function () {
+        it('Matches bsky.app/profile/{user}/post/{id}', function () {
+            const result = matchEmbedUrl('https://bsky.app/profile/user.bsky.social/post/3abc123def');
+            assert.equal(result.service, 'bluesky');
+            assert.equal(result.id, '3abc123def');
+        });
+    });
+
+    describe('TikTok', function () {
+        it('Matches tiktok.com/@{user}/video/{id}', function () {
+            const result = matchEmbedUrl('https://www.tiktok.com/@username/video/7123456789012345678');
+            assert.equal(result.service, 'tiktok');
+            assert.equal(result.id, '7123456789012345678');
+        });
+    });
+
+    describe('Non-matching URLs', function () {
+        it('Returns null for non-embed URL', function () {
+            const result = matchEmbedUrl('https://example.com/some-page');
+            assert.equal(result, null);
+        });
+
+        it('Returns null for empty string', function () {
+            const result = matchEmbedUrl('');
+            assert.equal(result, null);
+        });
+
+        it('Returns null for null', function () {
+            const result = matchEmbedUrl(null);
+            assert.equal(result, null);
+        });
+
+        it('Returns null for undefined', function () {
+            const result = matchEmbedUrl(undefined);
+            assert.equal(result, null);
+        });
+
+        it('Returns null for non-URL text', function () {
+            const result = matchEmbedUrl('This is just some text about youtube');
+            assert.equal(result, null);
+        });
+    });
+});
+
+describe('buildEmbedHtml', function () {
+    it('Returns null for null match', function () {
+        const result = buildEmbedHtml(null);
+        assert.equal(result, null);
+    });
+
+    it('Builds YouTube embed HTML', function () {
+        const match = matchEmbedUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+        const html = buildEmbedHtml(match);
+        assert.ok(html.includes('<figure class="kg-card kg-embed-card">'));
+        assert.ok(html.includes('src="https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed"'));
+        assert.ok(html.includes('</figure>'));
+    });
+
+    it('Builds Vimeo embed HTML', function () {
+        const match = matchEmbedUrl('https://vimeo.com/123456789');
+        const html = buildEmbedHtml(match);
+        assert.ok(html.includes('<figure class="kg-card kg-embed-card">'));
+        assert.ok(html.includes('src="https://player.vimeo.com/video/123456789"'));
+        assert.ok(html.includes('</figure>'));
+    });
+
+    it('Builds Spotify embed HTML with correct type', function () {
+        const match = matchEmbedUrl('https://open.spotify.com/track/4PTG3Z6ehGkBFwjybzWkR8');
+        const html = buildEmbedHtml(match);
+        assert.ok(html.includes('<figure class="kg-card kg-embed-card">'));
+        assert.ok(html.includes('src="https://open.spotify.com/embed/track/4PTG3Z6ehGkBFwjybzWkR8"'));
+        assert.ok(html.includes('</figure>'));
+    });
+
+    it('Builds Spotify album embed HTML', function () {
+        const match = matchEmbedUrl('https://open.spotify.com/album/1DFixLWuPkv3KT3TnV35m3');
+        const html = buildEmbedHtml(match);
+        assert.ok(html.includes('src="https://open.spotify.com/embed/album/1DFixLWuPkv3KT3TnV35m3"'));
+    });
+
+    it('Builds Dailymotion embed HTML', function () {
+        const match = matchEmbedUrl('https://www.dailymotion.com/video/x7tgad');
+        const html = buildEmbedHtml(match);
+        assert.ok(html.includes('<figure class="kg-card kg-embed-card">'));
+        assert.ok(html.includes('src="https://www.dailymotion.com/embed/video/x7tgad"'));
+        assert.ok(html.includes('</figure>'));
+    });
+
+    it('Builds Twitter embed HTML with comment markers', function () {
+        const match = matchEmbedUrl('https://twitter.com/user/status/1234567890');
+        const html = buildEmbedHtml(match);
+        assert.ok(html.includes('<!--kg-card-begin: embed-->'));
+        assert.ok(html.includes('<blockquote class="twitter-tweet">'));
+        assert.ok(html.includes('href="https://twitter.com/user/status/1234567890"'));
+        assert.ok(html.includes('platform.twitter.com/widgets.js'));
+        assert.ok(html.includes('<!--kg-card-end: embed-->'));
+    });
+
+    it('Builds X.com embed HTML with comment markers', function () {
+        const match = matchEmbedUrl('https://x.com/user/status/1234567890');
+        const html = buildEmbedHtml(match);
+        assert.ok(html.includes('<!--kg-card-begin: embed-->'));
+        assert.ok(html.includes('<blockquote class="twitter-tweet">'));
+        assert.ok(html.includes('href="https://x.com/user/status/1234567890"'));
+    });
+
+    it('Builds SoundCloud embed HTML as iframe', function () {
+        const match = matchEmbedUrl('https://soundcloud.com/artist/track-name');
+        const html = buildEmbedHtml(match);
+        assert.ok(html.includes('<figure class="kg-card kg-embed-card">'));
+        assert.ok(html.includes('<iframe'));
+        assert.ok(html.includes('src="https://soundcloud.com/artist/track-name"'));
+        assert.ok(html.includes('</figure>'));
+    });
+
+    it('Builds Instagram embed HTML as figure with blockquote', function () {
+        const match = matchEmbedUrl('https://www.instagram.com/p/CxYz123AbC/');
+        const html = buildEmbedHtml(match);
+        assert.ok(html.includes('<figure class="kg-card kg-embed-card">'));
+        assert.ok(html.includes('<blockquote'));
+        assert.ok(html.includes('href="https://www.instagram.com/p/CxYz123AbC/"'));
+        assert.ok(html.includes('instagram.com/embed.js'));
+    });
+
+    it('Builds Bluesky embed HTML as figure with blockquote', function () {
+        const match = matchEmbedUrl('https://bsky.app/profile/user.bsky.social/post/3abc123def');
+        const html = buildEmbedHtml(match);
+        assert.ok(html.includes('<figure class="kg-card kg-embed-card">'));
+        assert.ok(html.includes('<blockquote>'));
+        assert.ok(html.includes('href="https://bsky.app/profile/user.bsky.social/post/3abc123def"'));
+    });
+
+    it('Builds TikTok embed HTML as figure with blockquote', function () {
+        const match = matchEmbedUrl('https://www.tiktok.com/@username/video/7123456789012345678');
+        const html = buildEmbedHtml(match);
+        assert.ok(html.includes('<figure class="kg-card kg-embed-card">'));
+        assert.ok(html.includes('<blockquote>'));
+        assert.ok(html.includes('href="https://www.tiktok.com/@username/video/7123456789012345678"'));
+    });
+});

--- a/packages/mg-wp-api/test/embed-utils.test.js
+++ b/packages/mg-wp-api/test/embed-utils.test.js
@@ -317,3 +317,56 @@ describe('buildEmbedHtml', function () {
         assert.ok(html.includes('href="https://www.tiktok.com/@username/video/7123456789012345678"'));
     });
 });
+
+describe('URL sanitization', function () {
+    it('Escapes double quotes in URL attributes', function () {
+        const match = matchEmbedUrl('https://twitter.com/user/status/123');
+        assert.ok(match);
+        // Manually craft a match with an injected URL to test the builder
+        const malicious = {...match, url: 'https://twitter.com/user/status/123"onmouseover="alert(1)'};
+        const html = malicious.buildEmbedHtml(malicious.id, malicious.groups, malicious.url);
+        assert.ok(!html.includes('"onmouseover="alert(1)'));
+    });
+
+    it('Escapes angle brackets in URL attributes', function () {
+        const match = matchEmbedUrl('https://soundcloud.com/artist/track');
+        assert.ok(match);
+        const malicious = {...match, url: 'https://soundcloud.com/artist/track<script>alert(1)</script>'};
+        const html = malicious.buildEmbedHtml(malicious.id, malicious.groups, malicious.url);
+        assert.ok(!html.includes('<script>alert(1)</script>'));
+    });
+
+    it('Rejects javascript: protocol URLs', function () {
+        const match = matchEmbedUrl('https://twitter.com/user/status/456');
+        assert.ok(match);
+        const malicious = {...match, url: 'javascript:alert(1)'};
+        const html = malicious.buildEmbedHtml(malicious.id, malicious.groups, malicious.url);
+        assert.equal(html, '');
+    });
+
+    it('Rejects data: protocol URLs', function () {
+        const match = matchEmbedUrl('https://soundcloud.com/artist/track');
+        assert.ok(match);
+        const malicious = {...match, url: 'data:text/html,<script>alert(1)</script>'};
+        const html = malicious.buildEmbedHtml(malicious.id, malicious.groups, malicious.url);
+        assert.equal(html, '');
+    });
+
+    it('Rejects invalid URLs that fail URL constructor', function () {
+        const match = matchEmbedUrl('https://bsky.app/profile/user.bsky.social/post/abc123');
+        assert.ok(match);
+        const malicious = {...match, url: 'not-a-valid-url'};
+        const html = malicious.buildEmbedHtml(malicious.id, malicious.groups, malicious.url);
+        assert.equal(html, '');
+    });
+
+    it('URL with injection payload is sanitized in output', function () {
+        const result = matchEmbedUrl('https://twitter.com/user/status/123" onclick="alert(1)" data-x="');
+        // The regex matches (captures ID "123"), but output must be safe
+        assert.ok(result);
+        const html = buildEmbedHtml(result);
+        // The quotes are percent-encoded by URL constructor, so no attribute breakout
+        assert.ok(!html.includes('href="https://twitter.com/user/status/123"'));
+        assert.ok(html.includes('%22'));
+    });
+});

--- a/packages/mg-wp-api/test/process.test.js
+++ b/packages/mg-wp-api/test/process.test.js
@@ -1109,7 +1109,7 @@ const hello () => {
 
         let convertedHtml = await processor.processShortcodes({html});
 
-        assert.equal(convertedHtml, '<iframe loading="lazy" title="" width="160" height="90" src="https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe>');
+        assert.equal(convertedHtml, '<figure class="kg-card kg-embed-card"><iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed" width="160" height="90" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></figure>');
     });
 
     it('Can convert embed shortcode with youtube.com URL to iframe', async function () {
@@ -1117,7 +1117,7 @@ const hello () => {
 
         let convertedHtml = await processor.processShortcodes({html});
 
-        assert.equal(convertedHtml, '<iframe loading="lazy" title="" width="160" height="90" src="https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe>');
+        assert.equal(convertedHtml, '<figure class="kg-card kg-embed-card"><iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed" width="160" height="90" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></figure>');
     });
 
     it('Leaves embed shortcode content as-is for non-YouTube URLs', async function () {
@@ -1126,6 +1126,223 @@ const hello () => {
         let convertedHtml = await processor.processShortcodes({html});
 
         assert.equal(convertedHtml, 'https://example.com/some-page');
+    });
+
+    it('Can convert embed shortcode with Vimeo URL', async function () {
+        let html = '[embed]https://vimeo.com/123456789[/embed]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        assert.ok(convertedHtml.includes('player.vimeo.com/video/123456789'));
+        assert.ok(convertedHtml.includes('<figure class="kg-card kg-embed-card">'));
+    });
+
+    it('Can convert embed shortcode with Spotify URL', async function () {
+        let html = '[embed]https://open.spotify.com/track/4PTG3Z6ehGkBFwjybzWkR8[/embed]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        assert.ok(convertedHtml.includes('open.spotify.com/embed/track/4PTG3Z6ehGkBFwjybzWkR8'));
+        assert.ok(convertedHtml.includes('<figure class="kg-card kg-embed-card">'));
+    });
+
+    it('Can convert embed shortcode with Twitter URL', async function () {
+        let html = '[embed]https://twitter.com/user/status/1234567890[/embed]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        assert.ok(convertedHtml.includes('twitter-tweet'));
+        assert.ok(convertedHtml.includes('<!--kg-card-begin: embed-->'));
+    });
+});
+
+describe('processUnknownEmbedShortcodes (catch-all)', function () {
+    it('Converts unknown shortcode with YouTube URL as content', async function () {
+        let html = '[myvideo]https://www.youtube.com/watch?v=dQw4w9WgXcQ[/myvideo]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        assert.ok(convertedHtml.includes('youtube.com/embed/dQw4w9WgXcQ'));
+        assert.ok(convertedHtml.includes('<figure class="kg-card kg-embed-card">'));
+    });
+
+    it('Converts unknown shortcode with Vimeo URL as content', async function () {
+        let html = '[wp_video]https://vimeo.com/987654321[/wp_video]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        assert.ok(convertedHtml.includes('player.vimeo.com/video/987654321'));
+        assert.ok(convertedHtml.includes('<figure class="kg-card kg-embed-card">'));
+    });
+
+    it('Converts unknown shortcode with YouTube embed URL in attribute', async function () {
+        let html = '[video_embed url="https://www.youtube.com/embed/dQw4w9WgXcQ"]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        assert.ok(convertedHtml.includes('youtube.com/embed/dQw4w9WgXcQ'));
+        assert.ok(convertedHtml.includes('<figure class="kg-card kg-embed-card">'));
+    });
+
+    it('Converts unknown shortcode with YouTube URL in any attribute name', async function () {
+        let html = '[myshortcode video="https://www.youtube.com/watch?v=abc123" autoplay="false"]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        assert.ok(convertedHtml.includes('youtube.com/embed/abc123'));
+        assert.ok(convertedHtml.includes('<figure class="kg-card kg-embed-card">'));
+    });
+
+    it('Converts unknown shortcode with unquoted URL attribute', async function () {
+        let html = '[yt_player src=https://youtu.be/dQw4w9WgXcQ responsive=true]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        assert.ok(convertedHtml.includes('youtube.com/embed/dQw4w9WgXcQ'));
+        assert.ok(convertedHtml.includes('<figure class="kg-card kg-embed-card">'));
+    });
+
+    it('Does NOT convert unknown shortcode with mixed text content containing a URL', async function () {
+        let html = '[callout]Check out this video https://www.youtube.com/watch?v=dQw4w9WgXcQ and subscribe[/callout]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        assert.ok(!convertedHtml.includes('<figure class="kg-card kg-embed-card">'));
+        assert.ok(convertedHtml.includes('[callout]'));
+    });
+
+    it('Converts unknown shortcode with Instagram URL', async function () {
+        let html = '[ig_embed]https://www.instagram.com/p/CxYz123AbC/[/ig_embed]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        assert.ok(convertedHtml.includes('instagram.com/p/CxYz123AbC/'));
+        assert.ok(convertedHtml.includes('<blockquote'));
+        assert.ok(convertedHtml.includes('instagram.com/embed.js'));
+    });
+
+    it('Converts unknown shortcode with Bluesky URL', async function () {
+        let html = '[social_embed]https://bsky.app/profile/user.bsky.social/post/3abc123def[/social_embed]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        assert.ok(convertedHtml.includes('bsky.app/profile/user.bsky.social/post/3abc123def'));
+        assert.ok(convertedHtml.includes('<blockquote>'));
+    });
+
+    it('Converts unknown shortcode with TikTok URL', async function () {
+        let html = '[tiktok_video]https://www.tiktok.com/@user/video/7123456789012345678[/tiktok_video]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        assert.ok(convertedHtml.includes('tiktok.com/@user/video/7123456789012345678'));
+        assert.ok(convertedHtml.includes('<blockquote>'));
+    });
+
+    it('Converts unknown shortcode with Dailymotion URL', async function () {
+        let html = '[dm_video]https://www.dailymotion.com/video/x7tgad[/dm_video]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        assert.ok(convertedHtml.includes('dailymotion.com/embed/video/x7tgad'));
+        assert.ok(convertedHtml.includes('<figure class="kg-card kg-embed-card">'));
+    });
+
+    it('Converts unknown shortcode with SoundCloud URL', async function () {
+        let html = '[sc_player]https://soundcloud.com/artist-name/track-name[/sc_player]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        assert.ok(convertedHtml.includes('soundcloud.com/artist-name/track-name'));
+        assert.ok(convertedHtml.includes('<iframe'));
+    });
+
+    it('Leaves unknown shortcode with non-embed URL as-is', async function () {
+        let html = '[my_shortcode]https://example.com/some-page[/my_shortcode]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        assert.equal(convertedHtml, '[my_shortcode]https://example.com/some-page[/my_shortcode]');
+    });
+
+    it('Leaves unknown shortcode with non-URL content as-is', async function () {
+        let html = '[notice]This is a simple notice box[/notice]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        assert.equal(convertedHtml, '[notice]This is a simple notice box[/notice]');
+    });
+
+    it('Handles multiple unknown embed shortcodes in one HTML string', async function () {
+        let html = '<p>Video 1:</p>[vid1]https://youtu.be/abc123[/vid1]<p>Video 2:</p>[vid2]https://vimeo.com/456789[/vid2]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        assert.ok(convertedHtml.includes('youtube.com/embed/abc123'));
+        assert.ok(convertedHtml.includes('player.vimeo.com/video/456789'));
+    });
+
+    it('Converts self-closing shortcode with positional URL', async function () {
+        let html = '[video_player https://www.youtube.com/watch?v=test123]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        assert.ok(convertedHtml.includes('youtube.com/embed/test123'));
+        assert.ok(convertedHtml.includes('<figure class="kg-card kg-embed-card">'));
+    });
+
+    it('Converts X.com (new Twitter) URL in unknown shortcode', async function () {
+        let html = '[tweet_embed]https://x.com/user/status/9876543210[/tweet_embed]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        assert.ok(convertedHtml.includes('twitter-tweet'));
+        assert.ok(convertedHtml.includes('x.com/user/status/9876543210'));
+    });
+
+    it('Converts Spotify embed URL format', async function () {
+        let html = '[music]https://open.spotify.com/embed/album/1DFixLWuPkv3KT3TnV35m3[/music]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        assert.ok(convertedHtml.includes('open.spotify.com/embed/album/1DFixLWuPkv3KT3TnV35m3'));
+        assert.ok(convertedHtml.includes('<figure class="kg-card kg-embed-card">'));
+    });
+
+    it('Known [youtube] shortcode is handled by its own handler, not the catch-all', async function () {
+        let html = '[youtube id="dQw4w9WgXcQ"]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        // The known handler produces a bare iframe with loading="lazy" and referrerpolicy attrs
+        // The catch-all would produce a <figure class="kg-card kg-embed-card"> wrapper
+        assert.ok(convertedHtml.includes('loading="lazy"'), 'Should have loading="lazy" from known handler');
+        assert.ok(convertedHtml.includes('referrerpolicy="strict-origin-when-cross-origin"'), 'Should have referrerpolicy from known handler');
+        assert.ok(!convertedHtml.includes('<figure class="kg-card kg-embed-card">'), 'Should NOT have kg-embed-card wrapper from catch-all');
+    });
+
+    it('Known [embed] shortcode is handled by its own handler, not the catch-all', async function () {
+        let html = '[embed]https://youtu.be/dQw4w9WgXcQ[/embed]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        // The known [embed] handler uses matchEmbedUrl which produces the figure wrapper
+        assert.ok(convertedHtml.includes('<figure class="kg-card kg-embed-card">'));
+        assert.ok(convertedHtml.includes('youtube.com/embed/dQw4w9WgXcQ'));
+        // Verify shortcode is fully consumed (no leftover [embed] tags)
+        assert.ok(!convertedHtml.includes('[embed]'));
+        assert.ok(!convertedHtml.includes('[/embed]'));
+    });
+
+    it('Known [audio] shortcode is not affected by catch-all', async function () {
+        let html = '[audio mp3="https://example.com/podcast.mp3"]';
+
+        let convertedHtml = await processor.processShortcodes({html});
+
+        // Should be handled by the known audio handler, producing an <audio> element
+        assert.ok(convertedHtml.includes('<audio'));
+        assert.ok(convertedHtml.includes('podcast.mp3'));
+        assert.ok(!convertedHtml.includes('<figure class="kg-card kg-embed-card">'));
     });
 });
 


### PR DESCRIPTION
Adds a catch-all post-processing pass that detects embeddable service URLs (YouTube, Vimeo, Spotify, Twitter/X, Instagram, Bluesky, TikTok, SoundCloud, Dailymotion) inside any remaining shortcodes after known shortcode handling completes, and converts them to Ghost embed cards.

Also expands the existing [embed] shortcode handler to support all services instead of only YouTube.